### PR TITLE
feat(model): add enforcement for can_delete, can_create, can_update, …

### DIFF
--- a/docs/python/config.json
+++ b/docs/python/config.json
@@ -40,6 +40,19 @@
                         "save_finished",
                         "where_for_request"
                     ]
+                },
+                {
+                    "title": "Permissions",
+                    "attributes": [
+                        "can_delete",
+                        "can_create",
+                        "can_update",
+                        "can_query",
+                        "require_can_delete",
+                        "require_can_create",
+                        "require_can_update",
+                        "require_can_query"
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
…can_query

- Add documentation for permission attributes
- Add require_can_* hooks for overridable permission checks
- Enforce permissions in save(), delete(), __iter__, __len__
- Add Permissions section to docs config