### PR TITLE
feat(autodoc): auto-generate OpenAPI examples

### DIFF
--- a/src/clearskies/autodoc/__init__.py
+++ b/src/clearskies/autodoc/__init__.py
@@ -1,6 +1,7 @@
-from . import formats, request, response, schema
+from . import examples, formats, request, response, schema
 
 __all__ = [
+    "examples",
     "formats",
     "request",
     "response",

--- a/src/clearskies/autodoc/examples.py
+++ b/src/clearskies/autodoc/examples.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def schema_example(schema: Any) -> Any:
+    if schema is None:
+        return None
+
+    example = getattr(schema, "example", None)
+    if example is not None:
+        return example
+
+    value = getattr(schema, "value", None)
+    if value is not None:
+        return value
+
+    schema_type = getattr(schema, "_type", "")
+    schema_format = getattr(schema, "_format", "")
+    name = getattr(schema, "name", "value")
+
+    if schema_type == "object":
+        children = getattr(schema, "children", None) or []
+        return {child.name: schema_example(child) for child in children}
+
+    if schema_type == "array":
+        item = getattr(schema, "item_definition", None)
+        return [schema_example(item)]
+
+    options = getattr(schema, "options", None)
+    if options:
+        return schema_example(options[0])
+
+    option = getattr(schema, "option", None)
+    if option is not None:
+        return schema_example(option)
+
+    values = getattr(schema, "values", None)
+    if values:
+        return values[0]
+
+    if schema_type == "boolean":
+        return True
+    if schema_type == "integer":
+        return 1
+    if schema_type == "number":
+        return 1.5
+    if schema_type == "string":
+        lowered_name = str(name).lower()
+        if schema_format == "date-time":
+            return "2026-01-01T00:00:00Z"
+        if schema_format == "date":
+            return "2026-01-01"
+        if schema_format == "password":
+            return "example-password"
+        if "email" in lowered_name:
+            return "user@example.com"
+        if "phone" in lowered_name:
+            return "+12025550123"
+        if lowered_name in ("id", "uuid") or lowered_name.endswith("_id"):
+            return "00000000-0000-0000-0000-000000000001"
+        return "example-text"
+
+    return "example-value"

--- a/src/clearskies/autodoc/formats/oai3_json/parameter.py
+++ b/src/clearskies/autodoc/formats/oai3_json/parameter.py
@@ -56,5 +56,9 @@ class Parameter:
             output["example"] = self.parameter.example
         if self.parameter.examples is not None:
             output["examples"] = self.parameter.examples
+        if self.parameter.documentation_example is not None:
+            output["example"] = self.parameter.documentation_example
+        if self.parameter.documentation_examples is not None:
+            output["examples"] = self.parameter.documentation_examples
 
         return output

--- a/src/clearskies/autodoc/formats/oai3_json/request.py
+++ b/src/clearskies/autodoc/formats/oai3_json/request.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any
 
+from ... import examples
 from ...schema import Object
 from .parameter import Parameter
 from .response import Response
@@ -108,9 +109,30 @@ class Request:
                 for content_type, body_parameters in grouped_by_content_type.items():
                     definitions = [parameter.definition for parameter in body_parameters]
                     json_body = Object("body", definitions)
+                    override_example = next(
+                        (
+                            param.documentation_example
+                            for param in body_parameters
+                            if param.documentation_example is not None
+                        ),
+                        None,
+                    )
+                    override_examples = next(
+                        (
+                            param.documentation_examples
+                            for param in body_parameters
+                            if param.documentation_examples is not None
+                        ),
+                        None,
+                    )
                     content[content_type] = {
                         "schema": self.oai3_schema_resolver(json_body).convert(),
+                        "example": override_example
+                        if override_example is not None
+                        else examples.schema_example(json_body),
                     }
+                    if override_examples is not None:
+                        content[content_type]["examples"] = override_examples
 
                 request_body_description = (
                     self.request.description

--- a/src/clearskies/autodoc/request/json_body.py
+++ b/src/clearskies/autodoc/request/json_body.py
@@ -11,6 +11,14 @@ class JSONBody(Parameter):
         description="",
         required=False,
         content_type="application/json",
+        documentation_example=None,
+        documentation_examples=None,
     ):
-        super().__init__(definition=definition, description=description, required=required)
+        super().__init__(
+            definition=definition,
+            description=description,
+            required=required,
+            documentation_example=documentation_example,
+            documentation_examples=documentation_examples,
+        )
         self.content_type = content_type

--- a/src/clearskies/autodoc/request/parameter.py
+++ b/src/clearskies/autodoc/request/parameter.py
@@ -15,6 +15,8 @@ class Parameter:
         example=None,
         examples=None,
         content=None,
+        documentation_example=None,
+        documentation_examples=None,
     ):
         self.definition = definition
         self.description = description
@@ -27,3 +29,5 @@ class Parameter:
         self.example = example
         self.examples = examples
         self.content = content
+        self.documentation_example = documentation_example
+        self.documentation_examples = documentation_examples

--- a/src/clearskies/autodoc/response/response.py
+++ b/src/clearskies/autodoc/response/response.py
@@ -1,3 +1,6 @@
+from clearskies.autodoc import examples
+
+
 class Response:
     status = None
     schema = None
@@ -6,10 +9,36 @@ class Response:
     links = None
     content = None
 
-    def __init__(self, status, schema, description=None, headers=None, links=None, content=None):
+    def __init__(
+        self,
+        status,
+        schema,
+        description=None,
+        headers=None,
+        links=None,
+        content=None,
+        documentation_example=None,
+        documentation_examples=None,
+    ):
         self.status = status
         self.schema = schema
         self.description = description if description is not None else ""
         self.headers = headers if headers is not None else {}
         self.links = links if links is not None else {}
-        self.content = content if content is not None else {"application/json": {"schema": schema}}
+        if content is None:
+            content = {
+                "application/json": {
+                    "schema": schema,
+                }
+            }
+
+        for media_type, media_data in content.items():
+            if "example" not in media_data:
+                if documentation_example is not None:
+                    media_data["example"] = documentation_example
+                else:
+                    media_data["example"] = examples.schema_example(schema)
+            if documentation_examples is not None and "examples" not in media_data:
+                media_data["examples"] = documentation_examples
+
+        self.content = content

--- a/tests/autodoc/test_oai3_auto_examples.py
+++ b/tests/autodoc/test_oai3_auto_examples.py
@@ -1,0 +1,112 @@
+import json
+import unittest
+
+from clearskies.autodoc import schema as autodoc_schema
+from clearskies.autodoc.formats.oai3_json import Oai3Json, OAI3SchemaResolver
+from clearskies.autodoc.request import JSONBody, Request, URLParameter
+from clearskies.autodoc.response import Response
+
+
+class TestOai3AutoExamples(unittest.TestCase):
+    def test_auto_examples_for_request_body_and_response(self):
+        request = Request(
+            description="Create",
+            relative_path="/items",
+            request_methods=["POST"],
+            parameters=[
+                JSONBody(
+                    definition=autodoc_schema.String("name"),
+                    required=True,
+                )
+            ],
+            responses=[
+                Response(
+                    status=200,
+                    schema=autodoc_schema.Object(
+                        "body",
+                        [
+                            autodoc_schema.String("email"),
+                            autodoc_schema.Integer("count"),
+                            autodoc_schema.Boolean("enabled"),
+                        ],
+                    ),
+                    description="Ok",
+                )
+            ],
+        )
+
+        oai3_json = Oai3Json(OAI3SchemaResolver())
+        oai3_json.set_requests([request])
+        output = json.loads(oai3_json.compact())
+
+        request_example = output["paths"]["/items"]["post"]["requestBody"]["content"]["application/json"]["example"]
+        self.assertIn("name", request_example)
+
+        response_example = output["paths"]["/items"]["post"]["responses"]["200"]["content"]["application/json"][
+            "example"
+        ]
+        self.assertEqual(response_example["email"], "user@example.com")
+        self.assertEqual(response_example["count"], 1)
+        self.assertTrue(response_example["enabled"])
+
+    def test_override_examples_for_request_body_parameter(self):
+        request = Request(
+            description="Create",
+            relative_path="/items",
+            request_methods=["POST"],
+            parameters=[
+                JSONBody(
+                    definition=autodoc_schema.String("name"),
+                    required=True,
+                    documentation_example={"name": "override"},
+                    documentation_examples={"sample": {"value": {"name": "sample"}}},
+                )
+            ],
+            responses=[
+                Response(status=200, schema=autodoc_schema.String("message"), description="Ok"),
+            ],
+        )
+
+        oai3_json = Oai3Json(OAI3SchemaResolver())
+        oai3_json.set_requests([request])
+        output = json.loads(oai3_json.compact())
+        request_content = output["paths"]["/items"]["post"]["requestBody"]["content"]["application/json"]
+        self.assertEqual(request_content["example"], {"name": "override"})
+        self.assertIn("examples", request_content)
+
+    def test_override_examples_for_parameter_and_response(self):
+        request = Request(
+            description="Get",
+            relative_path="/items",
+            request_methods=["GET"],
+            parameters=[
+                URLParameter(
+                    definition=autodoc_schema.String("q"),
+                    documentation_example="override-q",
+                )
+            ],
+            responses=[
+                Response(
+                    status=200,
+                    schema=autodoc_schema.String("message"),
+                    description="Ok",
+                    documentation_example="override-message",
+                    documentation_examples={"sample": {"value": "sample-message"}},
+                )
+            ],
+        )
+
+        oai3_json = Oai3Json(OAI3SchemaResolver())
+        oai3_json.set_requests([request])
+        output = json.loads(oai3_json.compact())
+
+        parameter = output["paths"]["/items"]["get"]["parameters"][0]
+        self.assertEqual(parameter["example"], "override-q")
+
+        response_content = output["paths"]["/items"]["get"]["responses"]["200"]["content"]["application/json"]
+        self.assertEqual(response_content["example"], "override-message")
+        self.assertIn("examples", response_content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds deterministic, framework-level OpenAPI example generation in core autodoc.

## What this PR does

- Adds core auto-example generation helper:
  - `clearskies.autodoc.examples.schema_example(...)`
  - deterministic examples for object/array/composition/enum/scalars/formats
  - safe placeholder values (`user@example.com`, UUID placeholder, etc.)

- Adds override hooks for explicit documentation examples:
  - request parameters: `documentation_example`, `documentation_examples`
  - JSONBody: `documentation_example`, `documentation_examples`
  - responses: `documentation_example`, `documentation_examples`

- Wires automatic examples into OpenAPI output:
  - requestBody content examples auto-generated when not provided
  - response content examples auto-generated when not provided
  - parameter/JSONBody/response override hooks take precedence

## Files changed in this PR

- `src/clearskies/autodoc/__init__.py`
- `src/clearskies/autodoc/examples.py`
- `src/clearskies/autodoc/formats/oai3_json/parameter.py`
- `src/clearskies/autodoc/formats/oai3_json/request.py`
- `src/clearskies/autodoc/request/json_body.py`
- `src/clearskies/autodoc/request/parameter.py`
- `src/clearskies/autodoc/response/response.py`
- `tests/autodoc/test_oai3_auto_examples.py`

## Test coverage

- New:
  - `tests/autodoc/test_oai3_auto_examples.py`

This change is additive and focused on improving generated OpenAPI usability with realistic default examples and explicit override controls.
