### PR TITLE
fix: remove unused jose-jwt

### DIFF
--- a/src/clearskies/authentication/jwks.py
+++ b/src/clearskies/authentication/jwks.py
@@ -62,11 +62,6 @@ class Jwks(Authentication, di.InjectableProperties):
     requests = di.inject.Requests()
 
     """
-    The JoseJwt library
-    """
-    jose_jwt = di.inject.ByName("jose_jwt")
-
-    """
     The current time
     """
     now = di.inject.Now()


### PR DESCRIPTION
Remove the inject of jose_jwt. This package is no longer active maintained.

