### PR TITLE
refactor(authentication): dispatch auth response handling by status

### DIFF
--- a/src/clearskies/authentication/authentication.py
+++ b/src/clearskies/authentication/authentication.py
@@ -57,9 +57,6 @@ class Authentication(clearskies.configurable.Configurable, requests.auth.AuthBas
         handler = getattr(self, f"handle_{response.status_code}", self.handle_default)
         return handler(response, *args, **kwargs)
 
-    def reauth(self, response: requests.models.Response, *args: Any, **kwargs: Any) -> requests.models.Response:
-        return self.handle_auth_response(response, *args, **kwargs)
-
     def _retry_auth(self, response: requests.models.Response, **kwargs: Any) -> requests.models.Response:
         request = response.request
         if not request:

--- a/src/clearskies/authentication/authentication.py
+++ b/src/clearskies/authentication/authentication.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import requests
 import requests.auth
+from requests.structures import CaseInsensitiveDict
 
 import clearskies.configurable
 from clearskies.authentication.authorization import Authorization
@@ -18,6 +19,7 @@ class Authentication(clearskies.configurable.Configurable, requests.auth.AuthBas
     is_public = True
     can_authorize = False
     has_dynamic_credentials = False
+    max_auth_retries = 1
 
     def clear_credential_cache(self) -> None:
         pass
@@ -40,6 +42,35 @@ class Authentication(clearskies.configurable.Configurable, requests.auth.AuthBas
     def documentation_security_scheme_name(self) -> str:
         return ""
 
+    def reauth(self, response: requests.models.Response, **kwargs: Any) -> requests.models.Response:
+        if response.status_code not in (401, 403):
+            return response
+
+        request = response.request
+        if not request:
+            return response
+
+        retry_count = getattr(request, "_clearskies_auth_retry_count", 0)
+        if retry_count >= self.max_auth_retries:
+            return response
+
+        retry_request = request.copy()
+        retry_request.headers = CaseInsensitiveDict(dict(retry_request.headers or {}))
+        retry_request.headers.update(self.headers(retry_auth=True))
+        setattr(retry_request, "_clearskies_auth_retry_count", retry_count + 1)
+
+        connection = getattr(response, "connection", None)
+        if not connection:
+            return response
+
+        if getattr(response, "raw", None) and hasattr(response.raw, "drain_conn"):
+            response.raw.drain_conn()
+        else:
+            _ = response.content
+        response.close()
+        return connection.send(retry_request, **kwargs)
+
     def __call__(self, r: requests.models.PreparedRequest) -> requests.models.PreparedRequest:
+        r.register_hook("response", self.reauth)
         r.headers.update(self.headers())
         return r

--- a/src/clearskies/authentication/authentication.py
+++ b/src/clearskies/authentication/authentication.py
@@ -42,10 +42,25 @@ class Authentication(clearskies.configurable.Configurable, requests.auth.AuthBas
     def documentation_security_scheme_name(self) -> str:
         return ""
 
-    def reauth(self, response: requests.models.Response, **kwargs: Any) -> requests.models.Response:
-        if response.status_code not in (401, 403):
-            return response
+    def handle_401(self, response: requests.models.Response, *args: Any, **kwargs: Any) -> requests.models.Response:
+        return self._retry_auth(response, **kwargs)
 
+    def handle_403(self, response: requests.models.Response, *args: Any, **kwargs: Any) -> requests.models.Response:
+        return self._retry_auth(response, **kwargs)
+
+    def handle_default(self, response: requests.models.Response, *args: Any, **kwargs: Any) -> requests.models.Response:
+        return response
+
+    def handle_auth_response(
+        self, response: requests.models.Response, *args: Any, **kwargs: Any
+    ) -> requests.models.Response:
+        handler = getattr(self, f"handle_{response.status_code}", self.handle_default)
+        return handler(response, *args, **kwargs)
+
+    def reauth(self, response: requests.models.Response, *args: Any, **kwargs: Any) -> requests.models.Response:
+        return self.handle_auth_response(response, *args, **kwargs)
+
+    def _retry_auth(self, response: requests.models.Response, **kwargs: Any) -> requests.models.Response:
         request = response.request
         if not request:
             return response
@@ -71,6 +86,6 @@ class Authentication(clearskies.configurable.Configurable, requests.auth.AuthBas
         return connection.send(retry_request, **kwargs)
 
     def __call__(self, r: requests.models.PreparedRequest) -> requests.models.PreparedRequest:
-        r.register_hook("response", self.reauth)
+        r.register_hook("response", self.handle_auth_response)
         r.headers.update(self.headers())
         return r

--- a/src/clearskies/authentication/secret_bearer.py
+++ b/src/clearskies/authentication/secret_bearer.py
@@ -457,6 +457,7 @@ class SecretBearer(Authentication, di.InjectableProperties):
 
     _secret: str | None = None
     _alternate_secret: str | None = None
+    _force_secret_refresh: bool = False
 
     @decorators.parameters_to_properties
     def __init__(
@@ -476,9 +477,13 @@ class SecretBearer(Authentication, di.InjectableProperties):
     @property
     def secret(self):
         if self._secret is None:
-            self._secret = (
-                self.secrets.get(self.secret_key) if self.secret_key else self.environment.get(self.environment_key)
-            )
+            if self.secret_key:
+                try:
+                    self._secret = self.secrets.get(self.secret_key, refresh=self._force_secret_refresh)
+                finally:
+                    self._force_secret_refresh = False
+            else:
+                self._secret = self.environment.get(self.environment_key)
         return self._secret
 
     def clear_credential_cache(self):
@@ -500,9 +505,8 @@ class SecretBearer(Authentication, di.InjectableProperties):
 
     def headers(self, retry_auth: bool = False):
         if retry_auth:
-            self._alternate_secret = None
-            if self.secret_key:
-                self._secret = self.secrets.get(self.secret_key, refresh=True)
+            self._force_secret_refresh = True
+            self.clear_credential_cache()
 
         self._configured_guard()
         return {"Authorization": f"{self.header_prefix}{self.secret}"}

--- a/src/clearskies/authentication/secret_bearer.py
+++ b/src/clearskies/authentication/secret_bearer.py
@@ -475,22 +475,22 @@ class SecretBearer(Authentication, di.InjectableProperties):
 
     @property
     def secret(self):
-        if not self._secret:
+        if self._secret is None:
             self._secret = (
                 self.secrets.get(self.secret_key) if self.secret_key else self.environment.get(self.environment_key)
             )
         return self._secret
 
     def clear_credential_cache(self):
-        if self.secret_key:
-            self._secret = None
+        self._secret = None
+        self._alternate_secret = None
 
     @property
     def alternate_secret(self):
         if not self.alternate_secret_key and not self.alternate_environment_key:
             return ""
 
-        if not self._alternate_secret:
+        if self._alternate_secret is None:
             self._alternate_secret = (
                 self.secrets.get(self.alternate_secret_key)
                 if self.alternate_secret_key
@@ -498,10 +498,13 @@ class SecretBearer(Authentication, di.InjectableProperties):
             )
         return self._alternate_secret
 
-    def headers(self, retry_auth=False):
-        self._configured_guard()
+    def headers(self, retry_auth: bool = False):
         if retry_auth:
-            self.clear_credential_cache()
+            self._alternate_secret = None
+            if self.secret_key:
+                self._secret = self.secrets.get(self.secret_key, refresh=True)
+
+        self._configured_guard()
         return {"Authorization": f"{self.header_prefix}{self.secret}"}
 
     def authenticate(self, input_output):

--- a/src/clearskies/backends/api_backend.py
+++ b/src/clearskies/backends/api_backend.py
@@ -1239,7 +1239,6 @@ class ApiBackend(Backend, InjectableProperties):
         method: str,
         json: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
-        is_retry=False,
     ) -> RequestsResponse:
         """
         Execute the actual API request and returns the response object.
@@ -1254,17 +1253,13 @@ class ApiBackend(Backend, InjectableProperties):
         if headers is None:
             headers = {}
 
-        self.logger.debug(
-            f"Executing {method} request to {url} with headers {headers} and json {json} (retry={is_retry})"
-        )
+        self.logger.debug(f"Executing {method} request to {url} with headers {headers} and json {json}")
 
         if self.authentication:
             if not self._auth_injected:
                 self._auth_injected = True
                 if isinstance(self.authentication, InjectableProperties):
                     self.authentication.injectable_properties(self.di)
-            if is_retry:
-                self.authentication.clear_credential_cache()
         # the requests library seems to build a slightly different request if you specify the json parameter,
         # even if it is null, and this causes trouble for some picky servers
         if not json:
@@ -1284,13 +1279,9 @@ class ApiBackend(Backend, InjectableProperties):
             )
 
         if not response.ok:
-            if not is_retry and response.status_code == 401:
-                return self.execute_request(url, method, json=json, headers=headers, is_retry=True)
-            if not response.ok:
-                raise ValueError(
-                    f"Failed request.  Status code: {response.status_code}, message: "
-                    + response.content.decode("utf-8")
-                )
+            raise ValueError(
+                f"Failed request.  Status code: {response.status_code}, message: " + response.content.decode("utf-8")
+            )
 
         return response
 

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -32,7 +32,7 @@ class FakeConnection:
 
 
 class AuthenticationTest(unittest.TestCase):
-    def test_call_sets_initial_headers_and_reauth_hook(self):
+    def test_call_sets_initial_headers_and_response_hook(self):
         auth = TrackingAuthentication()
         request = requests.Request("GET", "https://example.com").prepare()
 
@@ -41,9 +41,9 @@ class AuthenticationTest(unittest.TestCase):
         self.assertIs(result, request)
         self.assertEqual("Bearer initial-token", request.headers["Authorization"])
         self.assertEqual([False], auth.header_calls)
-        self.assertIn(auth.reauth, request.hooks["response"])
+        self.assertIn(auth.handle_auth_response, request.hooks["response"])
 
-    def test_reauth_retries_401_with_refreshed_headers(self):
+    def test_handle_auth_response_retries_401_with_refreshed_headers(self):
         auth = TrackingAuthentication()
         request = requests.Request("GET", "https://example.com").prepare()
         request = auth(request)
@@ -55,7 +55,7 @@ class AuthenticationTest(unittest.TestCase):
         connection = FakeConnection()
         setattr(response, "connection", cast(Any, connection))
 
-        retry_response = auth.reauth(response, timeout=2)
+        retry_response = auth.handle_auth_response(response, timeout=2)
 
         self.assertEqual(200, retry_response.status_code)
         self.assertEqual([False, True], auth.header_calls)
@@ -65,7 +65,7 @@ class AuthenticationTest(unittest.TestCase):
         self.assertEqual(1, getattr(connection.sent_request, "_clearskies_auth_retry_count", 0))
         self.assertEqual({"timeout": 2}, connection.sent_kwargs)
 
-    def test_reauth_retries_403_with_refreshed_headers(self):
+    def test_handle_auth_response_retries_403_with_refreshed_headers(self):
         auth = TrackingAuthentication()
         request = requests.Request("GET", "https://example.com").prepare()
         request = auth(request)
@@ -77,12 +77,12 @@ class AuthenticationTest(unittest.TestCase):
         connection = FakeConnection()
         setattr(response, "connection", cast(Any, connection))
 
-        retry_response = auth.reauth(response)
+        retry_response = auth.handle_auth_response(response)
 
         self.assertEqual(200, retry_response.status_code)
         self.assertEqual([False, True], auth.header_calls)
 
-    def test_reauth_returns_original_response_when_connection_missing(self):
+    def test_handle_auth_response_returns_original_response_when_connection_missing(self):
         auth = TrackingAuthentication()
         request = requests.Request("GET", "https://example.com").prepare()
         request = auth(request)
@@ -91,11 +91,11 @@ class AuthenticationTest(unittest.TestCase):
         response.status_code = 401
         response.request = request
 
-        same_response = auth.reauth(response)
+        same_response = auth.handle_auth_response(response)
 
         self.assertIs(same_response, response)
 
-    def test_reauth_respects_max_retries(self):
+    def test_handle_auth_response_respects_max_retries(self):
         auth = TrackingAuthentication()
         request = requests.Request("GET", "https://example.com").prepare()
         setattr(request, "_clearskies_auth_retry_count", auth.max_auth_retries)
@@ -103,6 +103,24 @@ class AuthenticationTest(unittest.TestCase):
         response = requests.Response()
         response.status_code = 401
         response.request = request
+
+        same_response = auth.handle_auth_response(response)
+
+        self.assertIs(same_response, response)
+
+    def test_handle_auth_response_uses_default_handler_for_non_auth_status(self):
+        auth = TrackingAuthentication()
+        response = requests.Response()
+        response.status_code = 418
+
+        same_response = auth.handle_auth_response(response)
+
+        self.assertIs(same_response, response)
+
+    def test_reauth_alias_calls_handle_auth_response(self):
+        auth = TrackingAuthentication()
+        response = requests.Response()
+        response.status_code = 418
 
         same_response = auth.reauth(response)
 

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -1,0 +1,109 @@
+import unittest
+from typing import Any, cast
+
+import requests
+
+from clearskies.authentication.authentication import Authentication
+
+
+class TrackingAuthentication(Authentication):
+    def __init__(self):
+        self.header_calls = []
+
+    def headers(self, retry_auth: bool = False) -> dict[str, str]:
+        self.header_calls.append(retry_auth)
+        if retry_auth:
+            return {"Authorization": "Bearer refreshed-token"}
+        return {"Authorization": "Bearer initial-token"}
+
+
+class FakeConnection:
+    def __init__(self):
+        self.sent_request = None
+        self.sent_kwargs = {}
+
+    def send(self, request: requests.PreparedRequest, **kwargs: Any) -> requests.Response:
+        self.sent_request = request
+        self.sent_kwargs = kwargs
+        response = requests.Response()
+        response.status_code = 200
+        response._content = b""
+        return response
+
+
+class AuthenticationTest(unittest.TestCase):
+    def test_call_sets_initial_headers_and_reauth_hook(self):
+        auth = TrackingAuthentication()
+        request = requests.Request("GET", "https://example.com").prepare()
+
+        result = auth(request)
+
+        self.assertIs(result, request)
+        self.assertEqual("Bearer initial-token", request.headers["Authorization"])
+        self.assertEqual([False], auth.header_calls)
+        self.assertIn(auth.reauth, request.hooks["response"])
+
+    def test_reauth_retries_401_with_refreshed_headers(self):
+        auth = TrackingAuthentication()
+        request = requests.Request("GET", "https://example.com").prepare()
+        request = auth(request)
+
+        response = requests.Response()
+        response.status_code = 401
+        response.request = request
+        response._content = b""
+        connection = FakeConnection()
+        setattr(response, "connection", cast(Any, connection))
+
+        retry_response = auth.reauth(response, timeout=2)
+
+        self.assertEqual(200, retry_response.status_code)
+        self.assertEqual([False, True], auth.header_calls)
+        self.assertIsNotNone(connection.sent_request)
+        sent_request = cast(requests.PreparedRequest, connection.sent_request)
+        self.assertEqual("Bearer refreshed-token", sent_request.headers["Authorization"])
+        self.assertEqual(1, getattr(connection.sent_request, "_clearskies_auth_retry_count", 0))
+        self.assertEqual({"timeout": 2}, connection.sent_kwargs)
+
+    def test_reauth_retries_403_with_refreshed_headers(self):
+        auth = TrackingAuthentication()
+        request = requests.Request("GET", "https://example.com").prepare()
+        request = auth(request)
+
+        response = requests.Response()
+        response.status_code = 403
+        response.request = request
+        response._content = b""
+        connection = FakeConnection()
+        setattr(response, "connection", cast(Any, connection))
+
+        retry_response = auth.reauth(response)
+
+        self.assertEqual(200, retry_response.status_code)
+        self.assertEqual([False, True], auth.header_calls)
+
+    def test_reauth_returns_original_response_when_connection_missing(self):
+        auth = TrackingAuthentication()
+        request = requests.Request("GET", "https://example.com").prepare()
+        request = auth(request)
+
+        response = requests.Response()
+        response.status_code = 401
+        response.request = request
+
+        same_response = auth.reauth(response)
+
+        self.assertIs(same_response, response)
+
+    def test_reauth_respects_max_retries(self):
+        auth = TrackingAuthentication()
+        request = requests.Request("GET", "https://example.com").prepare()
+        setattr(request, "_clearskies_auth_retry_count", auth.max_auth_retries)
+
+        response = requests.Response()
+        response.status_code = 401
+        response.request = request
+
+        same_response = auth.reauth(response)
+
+        self.assertIs(same_response, response)

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -116,12 +116,3 @@ class AuthenticationTest(unittest.TestCase):
         same_response = auth.handle_auth_response(response)
 
         self.assertIs(same_response, response)
-
-    def test_reauth_alias_calls_handle_auth_response(self):
-        auth = TrackingAuthentication()
-        response = requests.Response()
-        response.status_code = 418
-
-        same_response = auth.reauth(response)
-
-        self.assertIs(same_response, response)

--- a/tests/authentication/test_secret_bearer.py
+++ b/tests/authentication/test_secret_bearer.py
@@ -29,7 +29,7 @@ class SecretBearerTest(unittest.TestCase):
         assert status_code == 401
 
     def test_secret_key(self):
-        def fetch_secret(path):
+        def fetch_secret(path, refresh=False):
             if path == "/path/to/my/secret":
                 return "SUPERSECRET"
             raise KeyError(f"Attempt to fetch non-existent secret: {path}")
@@ -52,7 +52,7 @@ class SecretBearerTest(unittest.TestCase):
         assert status_code == 401
 
     def test_alternate_secret_key(self):
-        def fetch_secret(path):
+        def fetch_secret(path, refresh=False):
             if path == "/path/to/my/secret":
                 return "SUPERSECRET"
             if path == "/path/to/alternate/secret":

--- a/tests/authentication/test_secret_bearer.py
+++ b/tests/authentication/test_secret_bearer.py
@@ -2,6 +2,7 @@ import unittest
 from types import SimpleNamespace
 
 import clearskies
+from clearskies.di.di import Di
 
 
 class SecretBearerTest(unittest.TestCase):
@@ -139,3 +140,26 @@ class SecretBearerTest(unittest.TestCase):
 
         status_code, response_data, response_headers = context(request_headers={"Authorization": "SUPERSECRET"})
         assert status_code == 401
+
+    def test_retry_auth_forces_secret_refresh_when_using_secret_manager(self):
+        calls = []
+
+        def fetch_secret(path, refresh=False):
+            calls.append((path, refresh))
+            if path == "/path/to/my/secret":
+                return "NEWSECRET" if refresh else "OLDSECRET"
+            raise KeyError(f"Attempt to fetch non-existent secret: {path}")
+
+        bearer = clearskies.authentication.SecretBearer(secret_key="/path/to/my/secret")
+        di = Di(bindings={"secrets": SimpleNamespace(get=fetch_secret)})
+        bearer.injectable_properties(di)
+
+        self.assertEqual({"Authorization": "OLDSECRET"}, bearer.headers())
+        self.assertEqual({"Authorization": "NEWSECRET"}, bearer.headers(retry_auth=True))
+        self.assertEqual(
+            [
+                ("/path/to/my/secret", False),
+                ("/path/to/my/secret", True),
+            ],
+            calls,
+        )


### PR DESCRIPTION
## What
- add `Authentication.handle_auth_response` as the response-hook entrypoint
- dispatch response handling by status code via `handle_<status>` methods (`401`, `403`) with `handle_default` fallback
- register `handle_auth_response` in `Authentication.__call__`
- remove `reauth` alias to keep the API surface clean
- update `SecretBearer` refresh flow to reuse `clear_credential_cache` + `secret` property path
  - add `_force_secret_refresh` internal flag
  - on `retry_auth=True`, force a fresh secret-manager read (`refresh=True`) on next secret load
- remove duplicate backend-level 401 auth-retry logic from `ApiBackend` so auth retry is owned by authentication hooks

## Why
- make status-specific auth response handling easy to override in child auth classes
- avoid duplicated retry logic between auth classes and API backend
- keep `SecretBearer` behavior DRY and aligned with maintainer feedback

## Tests
- updated and expanded `tests/authentication/test_authentication.py` for:
  - response hook registration
  - 401/403 retry paths
  - missing-connection fallback
  - max retry guard
  - default handler path
- updated `tests/authentication/test_secret_bearer.py` secret manager test doubles to support `refresh` argument
- validation run: `uv run pytest tests/authentication/test_authentication.py tests/authentication/test_secret_bearer.py tests/backends/test_api_backend.py` (`22 passed`)
- commit hook run: `605 passed`
