### PR TITLE
fix(di): exclude Injectable subclasses from add_modules() auto-registration

### DIFF
--- a/src/clearskies/di/di.py
+++ b/src/clearskies/di/di.py
@@ -21,6 +21,7 @@ import clearskies.input_outputs.input_output
 from clearskies.di.additional_config import AdditionalConfig
 from clearskies.di.additional_config_auto_import import AdditionalConfigAutoImport
 from clearskies.di.additional_mygrations_auto_import import AdditionalMygrationsAutoImport
+from clearskies.di.injectable import Injectable
 from clearskies.environment import Environment
 from clearskies.exceptions import MissingDependency
 from clearskies.functional import string
@@ -413,6 +414,19 @@ class Di:
                         # built-ins will end up here
                         continue
                     if class_root[:root_len] != root:
+                        continue
+                    if issubclass(item, Injectable):
+                        # Injectable subclasses (e.g. clearskies.di.inject.*) are DI-wiring
+                        # descriptors: they only do anything useful via the descriptor protocol
+                        # (__get__), when used as a class attribute (`foo = SomeInjectable()`) on
+                        # an InjectableProperties class. They are not domain/application classes
+                        # meant to be built standalone and resolved by name. Auto-registering them
+                        # here would let a bare `build_class()` call construct a useless, un-wired
+                        # instance (never invoking __get__) under a name derived from the class's
+                        # own name - silently shadowing any `provide_<name>` (AdditionalConfig)
+                        # method or explicit binding that was meant to provide that name, and
+                        # forcing every Injectable subclass's name to avoid colliding with any
+                        # such name across the entire scanned module tree.
                         continue
                     if issubclass(item, AdditionalConfigAutoImport):
                         init_args = inspect.getfullargspec(item)

--- a/tests/di/injectable_module/__init__.py
+++ b/tests/di/injectable_module/__init__.py
@@ -1,0 +1,22 @@
+"""Fixture module for tests/di/test_add_modules_excludes_injectable.py.
+
+Contains an `Injectable` subclass whose name would, if auto-registered by name via
+`Di.add_modules()`, collide with `provide_boto3_like_thing()` on `AdditionalConfigAutoImportExample`
+in the test file - mirroring the real-world clear-skies-aws bug this fixture exists to guard against
+(`clearskies_aws.di.inject.boto3.Boto3` colliding with the DI name "boto3").
+"""
+
+from clearskies.di.injectable import Injectable
+
+
+class Boto3LikeThing(Injectable):
+    def __init__(self, cache: bool = True):
+        self.cache = cache
+
+    def __get__(self, instance, parent):
+        if instance is None:
+            return self
+        return self._di.build_from_name("boto3_like_thing", cache=self.cache)
+
+
+__all__ = ["Boto3LikeThing"]

--- a/tests/di/test_add_modules_excludes_injectable.py
+++ b/tests/di/test_add_modules_excludes_injectable.py
@@ -1,0 +1,90 @@
+"""Regression tests: Di.add_modules() must not auto-register Injectable subclasses by name.
+
+Injectable subclasses (clearskies.di.inject.*, and any third-party equivalents) only do anything
+useful via the descriptor protocol (`__get__`), when used as a class attribute
+(`foo = SomeInjectable()`) on an `InjectableProperties` class. They are not domain/application
+classes meant to be built standalone and resolved by name.
+
+Before this fix, `add_modules()` treated every discovered class the same way (aside from
+`AdditionalConfigAutoImport`/`AdditionalMygrationsAutoImport`), including `Injectable` subclasses.
+Since `add_classes()` derives a DI name from the class name (TitleCase -> snake_case), any
+`Injectable` subclass whose name happened to match a `provide_<name>` method elsewhere in the same
+module tree would silently shadow it: `build_from_name(name)` checks registered classes before
+`AdditionalConfig`/`provide_<name>` methods, so callers received a bare, un-wired instance of the
+`Injectable` subclass (built via a plain constructor call, never through `__get__`) instead of
+whatever the `provide_<name>` method was supposed to build.
+
+This is exactly what happened in clear-skies-aws: `clearskies_aws.di.inject.boto3.Boto3` collided
+with the DI name "boto3", breaking `BaseAwsClient.boto3 = ByStandardLib("boto3")` with
+`AttributeError: 'Boto3' object has no attribute 'client'`.
+"""
+
+import unittest
+
+from clearskies.di import AdditionalConfigAutoImport, Di
+from clearskies.di.injectable import Injectable
+
+
+class AdditionalConfigAutoImportExample(AdditionalConfigAutoImport):
+    def provide_boto3_like_thing(self) -> str:
+        return "the real thing"
+
+
+class AddModulesExcludesInjectableTest(unittest.TestCase):
+    def test_injectable_subclass_is_not_registered_as_a_class(self):
+        import tests.di.injectable_module as injectable_module
+
+        di = Di()
+        di.add_modules([injectable_module])
+
+        self.assertNotIn("boto3_like_thing", di._classes)
+
+    def test_provide_method_is_not_shadowed_by_a_same_named_injectable(self):
+        import tests.di.injectable_module as injectable_module
+
+        di = Di()
+        di.add_modules([injectable_module])
+        di.add_additional_configs([AdditionalConfigAutoImportExample()])
+
+        result = di.build_from_name("boto3_like_thing")
+
+        self.assertEqual("the real thing", result)
+
+    def test_injectable_subclass_still_works_normally_as_a_descriptor(self):
+        """The exclusion must not break legitimate Injectable usage as a class attribute."""
+        import tests.di.injectable_module as injectable_module
+        from clearskies.di.injectable_properties import InjectableProperties
+
+        class Consumer(InjectableProperties):
+            boto3_like_thing = injectable_module.Boto3LikeThing()
+
+        di = Di()
+        di.add_modules([injectable_module])
+        di.add_additional_configs([AdditionalConfigAutoImportExample()])
+
+        consumer = di.build_class(Consumer)
+        self.assertEqual("the real thing", consumer.boto3_like_thing)
+
+    def test_bare_injectable_class_is_excluded_too(self):
+        """Sanity check directly against the abstract base, not just a fixture subclass."""
+
+        class SomeInjectable(Injectable):
+            def __get__(self, instance, parent):
+                if instance is None:
+                    return self
+                return "unused"
+
+        import types
+
+        module = types.ModuleType("synthetic_injectable_module")
+        module.__file__ = __file__
+        module.__dict__["SomeInjectable"] = SomeInjectable
+
+        di = Di()
+        di.add_modules([module])
+
+        self.assertNotIn("some_injectable", di._classes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`Di.add_modules()` registers every discovered class by name (via `add_classes()`), with two
exceptions: `AdditionalConfigAutoImport` and `AdditionalMygrationsAutoImport` subclasses, which are
routed to their own dedicated registration mechanisms instead.

`Injectable` subclasses were not excluded. But `Injectable` subclasses only do anything useful
through the descriptor protocol (`__get__`), when used as a class attribute
(`foo = SomeInjectable()`) on an `InjectableProperties` class - they are not domain/application
classes meant to be built standalone and resolved by name.

Since `build_from_name()` checks registered classes before `AdditionalConfig`/`provide_<name>`
methods, any `Injectable` subclass whose name happened to convert to the same DI name (TitleCase ->
snake_case) as a `provide_<name>` method elsewhere in the scanned module tree would silently shadow
it - `build_class()` would construct a bare, un-wired instance of the `Injectable` subclass (never
invoking `__get__`) instead of whatever the `provide_<name>` method was supposed to build.

This is exactly what broke `clear-skies-aws`: `clearskies_aws.di.inject.boto3.Boto3` collided with
the DI name `"boto3"`, causing `AttributeError: 'Boto3' object has no attribute 'client'` in
`BaseAwsClient.boto3 = ByStandardLib("boto3")` for any app registering `modules=[clearskies_aws, ...]`
(the standard pattern).

## Fix

`add_modules()` now skips `Injectable` subclasses, the same way it already skips
`AdditionalConfigAutoImport`/`AdditionalMygrationsAutoImport`.

## Tests

- 4 new regression tests in `tests/di/test_add_modules_excludes_injectable.py` (verified they fail
  without the fix, pass with it).
- Full suite: 611/611 passing.