### PR TITLE
feat(backends): add pluggable ResponseAdapter extension point to ApiBackend

### DIFF
--- a/src/clearskies/backends/__init__.py
+++ b/src/clearskies/backends/__init__.py
@@ -44,6 +44,7 @@ class MyModel(clearskies.model):
 
 # from .api_backend import ApiBackend
 # from .api_get_only_backend import ApiGetOnlyBackend
+from clearskies.backends import adapters
 from clearskies.backends.api_backend import ApiBackend
 from clearskies.backends.backend import Backend
 from clearskies.backends.cursor_backend import CursorBackend
@@ -57,6 +58,7 @@ from clearskies.backends.memory_backend import MemoryBackend
 
 
 __all__ = [
+    "adapters",
     "ApiBackend",
     # "ApiGetOnlyBackend",
     "Backend",

--- a/src/clearskies/backends/adapters/__init__.py
+++ b/src/clearskies/backends/adapters/__init__.py
@@ -1,0 +1,8 @@
+"""Response adapters for ApiBackend response-envelope extraction."""
+
+from clearskies.backends.adapters.response_adapter import DefaultResponseAdapter, ResponseAdapter
+
+__all__ = [
+    "DefaultResponseAdapter",
+    "ResponseAdapter",
+]

--- a/src/clearskies/backends/adapters/__init__.py
+++ b/src/clearskies/backends/adapters/__init__.py
@@ -1,8 +1,7 @@
 """Response adapters for ApiBackend response-envelope extraction."""
 
-from clearskies.backends.adapters.response_adapter import DefaultResponseAdapter, ResponseAdapter
+from clearskies.backends.adapters.response_adapter import ResponseAdapter
 
 __all__ = [
-    "DefaultResponseAdapter",
     "ResponseAdapter",
 ]

--- a/src/clearskies/backends/adapters/response_adapter.py
+++ b/src/clearskies/backends/adapters/response_adapter.py
@@ -1,0 +1,138 @@
+"""ResponseAdapter protocol and default implementation for ApiBackend response extraction."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ResponseAdapter(ABC):
+    """
+    Pluggable response-extraction strategy for ``ApiBackend``.
+
+    Sits between ``execute_request()`` returning the raw response JSON and the
+    ``map_to_model`` pipeline.  Its sole responsibility is answering the
+    *structural* question — **where is the data inside the envelope?** — leaving
+    the *field-level* question (column name mapping, casing, etc.) to
+    ``api_to_model_map`` and ``map_to_model`` as before.
+
+    ## Implementing a custom adapter
+
+    Subclass ``ResponseAdapter`` and override both methods.  Return ``None`` from
+    either method to signal "I cannot handle this shape; fall through to the
+    built-in ``ApiBackend`` logic":
+
+    ```python
+    import clearskies
+
+
+    class MyServiceResponseAdapter(clearskies.backends.ResponseAdapter):
+        def extract_records(self, response_data):
+            # unwrap {"results": [...]}
+            return response_data.get("results")
+
+        def extract_record(self, response_data):
+            # unwrap {"item": {...}}
+            return response_data.get("item")
+    ```
+
+    Attach it to an ``ApiBackend`` subclass (or directly to an instance):
+
+    ```python
+    class MyServiceBackend(clearskies.backends.ApiBackend):
+        def __init__(self):
+            super().__init__(
+                base_url="https://api.example.com",
+                response_adapter=MyServiceResponseAdapter(),
+            )
+    ```
+
+    ## Using a callable
+
+    For simple cases a plain callable may be supplied instead of a full subclass.
+    The callable receives the raw response data and should return the extracted
+    value, or ``None`` to fall through:
+
+    ```python
+    backend = clearskies.backends.ApiBackend(
+        base_url="https://api.example.com",
+        response_adapter=lambda data: data.get("items"),
+    )
+    ```
+
+    When a callable is provided it is invoked for **both** ``extract_records`` and
+    ``extract_record`` calls.
+    """
+
+    @abstractmethod
+    def extract_records(self, response_data: Any) -> list[dict[str, Any]] | None:
+        """
+        Extract a list of raw record dicts from the response envelope.
+
+        Parameters
+        ----------
+        response_data:
+            The parsed JSON body returned by the API.
+
+        Returns
+        -------
+        list[dict] | None
+            The raw list of records, or ``None`` to fall through to the default
+            ``ApiBackend`` extraction logic.
+        """
+
+    @abstractmethod
+    def extract_record(self, response_data: Any) -> dict[str, Any] | None:
+        """
+        Extract a single raw record dict from the response envelope.
+
+        Parameters
+        ----------
+        response_data:
+            The parsed JSON body returned by the API.
+
+        Returns
+        -------
+        dict | None
+            The raw record dict, or ``None`` to fall through to the default
+            ``ApiBackend`` extraction logic.
+        """
+
+
+class DefaultResponseAdapter(ResponseAdapter):
+    """
+    The default response-extraction strategy used by ``ApiBackend``.
+
+    Encapsulates the extraction heuristics that were previously embedded
+    directly in ``map_records_response`` and ``map_record_response``:
+
+    - **Records**: if the response is already a ``list``, return it as-is.
+      If it is a ``dict``, return the first ``list`` value found one level
+      deep.  Return ``None`` for anything else (e.g. a single-record dict),
+      letting ``ApiBackend`` apply its column-aware single-record fallback.
+    - **Single record**: always return ``None`` — the existing
+      ``check_dict_and_map_to_model`` logic inside ``ApiBackend`` is
+      sufficient for the default case and requires column knowledge that the
+      adapter does not have.
+    """
+
+    def extract_records(self, response_data: Any) -> list[dict[str, Any]] | None:
+        """Return the record list from a plain list or a one-level-deep dict wrapper."""
+        if isinstance(response_data, list):
+            return response_data
+        if not isinstance(response_data, dict):
+            return None
+        for value in response_data.values():
+            if isinstance(value, list):
+                return value
+        return None
+
+    def extract_record(self, response_data: Any) -> dict[str, Any] | None:
+        """
+        Return ``None`` — delegate to the column-aware ``ApiBackend`` logic.
+
+        Override this in a custom adapter when the API wraps single records in
+        an envelope (e.g. ``{"data": {...}}``) that should be unwrapped before
+        ``map_to_model`` runs.
+        """
+        return None

--- a/src/clearskies/backends/adapters/response_adapter.py
+++ b/src/clearskies/backends/adapters/response_adapter.py
@@ -1,12 +1,11 @@
-"""ResponseAdapter protocol and default implementation for ApiBackend response extraction."""
+"""ResponseAdapter base implementation for ApiBackend response extraction."""
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from typing import Any
 
 
-class ResponseAdapter(ABC):
+class ResponseAdapter:
     """
     Pluggable response-extraction strategy for ``ApiBackend``.
 
@@ -18,7 +17,7 @@ class ResponseAdapter(ABC):
 
     ## Implementing a custom adapter
 
-    Subclass ``ResponseAdapter`` and override both methods.  Return ``None`` from
+    Subclass ``ResponseAdapter`` and override either/both methods.  Return ``None`` from
     either method to signal "I cannot handle this shape; fall through to the
     built-in ``ApiBackend`` logic":
 
@@ -64,7 +63,6 @@ class ResponseAdapter(ABC):
     ``extract_record`` calls.
     """
 
-    @abstractmethod
     def extract_records(self, response_data: Any) -> list[dict[str, Any]] | None:
         """
         Extract a list of raw record dicts from the response envelope.
@@ -79,9 +77,21 @@ class ResponseAdapter(ABC):
         list[dict] | None
             The raw list of records, or ``None`` to fall through to the default
             ``ApiBackend`` extraction logic.
-        """
 
-    @abstractmethod
+        Default behavior:
+        - If ``response_data`` is a ``list``, return it as-is.
+        - If ``response_data`` is a ``dict``, return the first one-level-deep ``list`` value.
+        - Otherwise return ``None``.
+        """
+        if isinstance(response_data, list):
+            return response_data
+        if not isinstance(response_data, dict):
+            return None
+        for value in response_data.values():
+            if isinstance(value, list):
+                return value
+        return None
+
     def extract_record(self, response_data: Any) -> dict[str, Any] | None:
         """
         Extract a single raw record dict from the response envelope.
@@ -96,43 +106,8 @@ class ResponseAdapter(ABC):
         dict | None
             The raw record dict, or ``None`` to fall through to the default
             ``ApiBackend`` extraction logic.
-        """
 
-
-class DefaultResponseAdapter(ResponseAdapter):
-    """
-    The default response-extraction strategy used by ``ApiBackend``.
-
-    Encapsulates the extraction heuristics that were previously embedded
-    directly in ``map_records_response`` and ``map_record_response``:
-
-    - **Records**: if the response is already a ``list``, return it as-is.
-      If it is a ``dict``, return the first ``list`` value found one level
-      deep.  Return ``None`` for anything else (e.g. a single-record dict),
-      letting ``ApiBackend`` apply its column-aware single-record fallback.
-    - **Single record**: always return ``None`` — the existing
-      ``check_dict_and_map_to_model`` logic inside ``ApiBackend`` is
-      sufficient for the default case and requires column knowledge that the
-      adapter does not have.
-    """
-
-    def extract_records(self, response_data: Any) -> list[dict[str, Any]] | None:
-        """Return the record list from a plain list or a one-level-deep dict wrapper."""
-        if isinstance(response_data, list):
-            return response_data
-        if not isinstance(response_data, dict):
-            return None
-        for value in response_data.values():
-            if isinstance(value, list):
-                return value
-        return None
-
-    def extract_record(self, response_data: Any) -> dict[str, Any] | None:
-        """
-        Return ``None`` — delegate to the column-aware ``ApiBackend`` logic.
-
-        Override this in a custom adapter when the API wraps single records in
-        an envelope (e.g. ``{"data": {...}}``) that should be unwrapped before
-        ``map_to_model`` runs.
+        Default behavior:
+        - Return ``None`` and delegate to the column-aware ``ApiBackend`` logic.
         """
         return None

--- a/src/clearskies/backends/api_backend.py
+++ b/src/clearskies/backends/api_backend.py
@@ -10,10 +10,10 @@ from clearskies import columns, configs, decorators
 from clearskies.autodoc.schema import Integer as AutoDocInteger
 from clearskies.autodoc.schema import Schema as AutoDocSchema
 from clearskies.autodoc.schema import String as AutoDocString
-from clearskies.backends.adapters import DefaultResponseAdapter
-from clearskies.backends.adapters import ResponseAdapter as ResponseAdapterABC
+from clearskies.backends.adapters import ResponseAdapter
 from clearskies.backends.backend import Backend
 from clearskies.di import InjectableProperties, inject
+from clearskies.exceptions import MissingDependency
 from clearskies.functional import json as json_functional
 from clearskies.functional import routing, string
 from clearskies.query.result import (
@@ -617,10 +617,17 @@ class ApiBackend(Backend, InjectableProperties):
     Return ``None`` from either the adapter method or the callable to fall through to the
     built-in ``ApiBackend`` extraction logic.
 
-    Defaults to :class:`~clearskies.backends.DefaultResponseAdapter`, which mirrors the
-    heuristics previously embedded in ``map_records_response``.
+    If not provided, clearskies checks DI for a dependency named
+    ``response_adapter`` and uses it when available. If no DI dependency exists,
+    a plain :class:`~clearskies.backends.ResponseAdapter` is used.
     """
-    response_adapter = configs.ResponseAdapter(default=DefaultResponseAdapter())
+    response_adapter = configs.ResponseAdapter(default=None)
+
+    """
+    Dependency name used to lazily resolve a response adapter from DI when
+    ``response_adapter`` is not explicitly configured.
+    """
+    response_adapter_dependency_name = configs.String(default="response_adapter")
 
     """
     The name of the pagination parameter
@@ -651,6 +658,7 @@ class ApiBackend(Backend, InjectableProperties):
 
     _auth_injected = False
     _response_to_model_map: dict[str, str] | None = None
+    _resolved_response_adapter: ResponseAdapter | Callable | None = None
 
     @decorators.parameters_to_properties
     def __init__(
@@ -673,7 +681,8 @@ class ApiBackend(Backend, InjectableProperties):
         can_update: bool | None = True,
         can_delete: bool | None = True,
         can_query: bool | None = True,
-        response_adapter: ResponseAdapterABC | None = None,
+        response_adapter: ResponseAdapter | Callable | None = None,
+        response_adapter_dependency_name: str = "response_adapter",
     ):
         self.finalize_and_validate_configuration()
 
@@ -1036,11 +1045,11 @@ class ApiBackend(Backend, InjectableProperties):
 
         # Allow the response_adapter to pre-process the raw response data before the standard mapping
         # logic runs.  A non-None return value replaces response_data; None means "pass through".
-        adapter = self.response_adapter
+        adapter = self.get_response_adapter()
         if adapter is not None:
             extracted = (
                 adapter(response_data)
-                if callable(adapter) and not isinstance(adapter, ResponseAdapterABC)
+                if callable(adapter) and not isinstance(adapter, ResponseAdapter)
                 else adapter.extract_records(response_data)
             )
             if extracted is not None:
@@ -1079,7 +1088,10 @@ class ApiBackend(Backend, InjectableProperties):
         )
 
     def map_record_response(
-        self, response_data: dict[str, Any], columns: dict[str, Column], operation: str
+        self,
+        response_data: dict[str, Any],
+        columns: dict[str, Column],
+        operation: str,
     ) -> dict[str, Any]:
         """
         Take the response from an API endpoint that returns a single record (typically update and create requests) and return the data for a new model.
@@ -1094,11 +1106,11 @@ class ApiBackend(Backend, InjectableProperties):
         """
         # Allow the response_adapter to pre-process the raw response data before the standard mapping
         # logic runs.  A non-None return value replaces response_data; None means "pass through".
-        adapter = self.response_adapter
+        adapter = self.get_response_adapter()
         if adapter is not None:
             extracted = (
                 adapter(response_data)
-                if callable(adapter) and not isinstance(adapter, ResponseAdapterABC)
+                if callable(adapter) and not isinstance(adapter, ResponseAdapter)
                 else adapter.extract_record(response_data)
             )
             if extracted is not None:
@@ -1117,6 +1129,21 @@ class ApiBackend(Backend, InjectableProperties):
             )
 
         return response
+
+    def get_response_adapter(self) -> ResponseAdapter | Callable | None:
+        """Return the active response adapter."""
+        if self.response_adapter is not None:
+            return self.response_adapter
+
+        if self._resolved_response_adapter is not None:
+            return self._resolved_response_adapter
+
+        try:
+            self._resolved_response_adapter = self.di.build(self.response_adapter_dependency_name)
+        except MissingDependency:
+            self._resolved_response_adapter = ResponseAdapter()
+
+        return self._resolved_response_adapter
 
     def map_to_model(
         self,

--- a/src/clearskies/backends/api_backend.py
+++ b/src/clearskies/backends/api_backend.py
@@ -618,8 +618,7 @@ class ApiBackend(Backend, InjectableProperties):
     built-in ``ApiBackend`` extraction logic.
 
     If not provided, clearskies checks DI for a dependency named
-    ``response_adapter`` and uses it when available. If no DI dependency exists,
-    a plain :class:`~clearskies.backends.ResponseAdapter` is used.
+    ``response_adapter`` and uses it when available.
     """
     response_adapter = configs.ResponseAdapter(default=None)
 
@@ -1052,8 +1051,11 @@ class ApiBackend(Backend, InjectableProperties):
                 if callable(adapter) and not isinstance(adapter, ResponseAdapter)
                 else adapter.extract_records(response_data)
             )
-            if extracted is not None:
-                response_data = extracted
+            if extracted is None:
+                raise ValueError(
+                    "A response adapter was configured, but it did not extract records from the API response.  Please update your adapter to return the records list for this response shape."
+                )
+            response_data = extracted
 
         # if our response is actually a list, then presumably the problem is solved.  If the response is a list
         # and the individual items aren't model results though... well, then I'm very confused
@@ -1113,8 +1115,11 @@ class ApiBackend(Backend, InjectableProperties):
                 if callable(adapter) and not isinstance(adapter, ResponseAdapter)
                 else adapter.extract_record(response_data)
             )
-            if extracted is not None:
-                response_data = extracted
+            if extracted is None:
+                raise ValueError(
+                    f"A response adapter was configured, but it did not extract a record from the API response for {operation}.  Please update your adapter to return the record dictionary for this response shape."
+                )
+            response_data = extracted
 
         an = "a" if operation == "create" else "an"
         if not isinstance(response_data, dict):
@@ -1141,7 +1146,7 @@ class ApiBackend(Backend, InjectableProperties):
         try:
             self._resolved_response_adapter = self.di.build(self.response_adapter_dependency_name)
         except MissingDependency:
-            self._resolved_response_adapter = ResponseAdapter()
+            self._resolved_response_adapter = None
 
         return self._resolved_response_adapter
 

--- a/src/clearskies/backends/api_backend.py
+++ b/src/clearskies/backends/api_backend.py
@@ -10,6 +10,8 @@ from clearskies import columns, configs, decorators
 from clearskies.autodoc.schema import Integer as AutoDocInteger
 from clearskies.autodoc.schema import Schema as AutoDocSchema
 from clearskies.autodoc.schema import String as AutoDocString
+from clearskies.backends.adapters import DefaultResponseAdapter
+from clearskies.backends.adapters import ResponseAdapter as ResponseAdapterABC
 from clearskies.backends.backend import Backend
 from clearskies.di import InjectableProperties, inject
 from clearskies.functional import json as json_functional
@@ -590,6 +592,37 @@ class ApiBackend(Backend, InjectableProperties):
     api_to_model_map = configs.AnyDict(default={})
 
     """
+    A :class:`~clearskies.backends.ResponseAdapter` that handles extracting records and single
+    records from the raw API response **before** the model-mapping pipeline runs.
+
+    The adapter answers the structural question — *where is the data inside the envelope?* —
+    while ``api_to_model_map`` and ``map_to_model`` continue to answer the field-level question
+    (*what are the fields called?*) as before.
+
+    Provide a :class:`~clearskies.backends.ResponseAdapter` subclass for full control, or a
+    plain callable ``(response_data: Any) -> list | dict | None`` for simple unwrapping::
+
+        # Full adapter — different logic per operation:
+        backend = clearskies.backends.ApiBackend(
+            base_url="https://api.example.com",
+            response_adapter=MyHalJsonResponseAdapter(),
+        )
+
+        # Callable — same extractor for both list and single-record responses:
+        backend = clearskies.backends.ApiBackend(
+            base_url="https://api.example.com",
+            response_adapter=lambda data: data.get("items"),
+        )
+
+    Return ``None`` from either the adapter method or the callable to fall through to the
+    built-in ``ApiBackend`` extraction logic.
+
+    Defaults to :class:`~clearskies.backends.DefaultResponseAdapter`, which mirrors the
+    heuristics previously embedded in ``map_records_response``.
+    """
+    response_adapter = configs.ResponseAdapter(default=DefaultResponseAdapter())
+
+    """
     The name of the pagination parameter
     """
     pagination_parameter_name = configs.String(default="start")
@@ -640,6 +673,7 @@ class ApiBackend(Backend, InjectableProperties):
         can_update: bool | None = True,
         can_delete: bool | None = True,
         can_query: bool | None = True,
+        response_adapter: ResponseAdapterABC | None = None,
     ):
         self.finalize_and_validate_configuration()
 
@@ -1000,6 +1034,18 @@ class ApiBackend(Backend, InjectableProperties):
                     continue
                 query_data[condition.column_name] = condition.values[0]
 
+        # Allow the response_adapter to pre-process the raw response data before the standard mapping
+        # logic runs.  A non-None return value replaces response_data; None means "pass through".
+        adapter = self.response_adapter
+        if adapter is not None:
+            extracted = (
+                adapter(response_data)
+                if callable(adapter) and not isinstance(adapter, ResponseAdapterABC)
+                else adapter.extract_records(response_data)
+            )
+            if extracted is not None:
+                response_data = extracted
+
         # if our response is actually a list, then presumably the problem is solved.  If the response is a list
         # and the individual items aren't model results though... well, then I'm very confused
         if isinstance(response_data, list):
@@ -1046,6 +1092,18 @@ class ApiBackend(Backend, InjectableProperties):
         endoint.  If this happens, you have to make a new API backend, override the map_record_response method
         to manage the mapping yourself, and then attach this new backend to your models.
         """
+        # Allow the response_adapter to pre-process the raw response data before the standard mapping
+        # logic runs.  A non-None return value replaces response_data; None means "pass through".
+        adapter = self.response_adapter
+        if adapter is not None:
+            extracted = (
+                adapter(response_data)
+                if callable(adapter) and not isinstance(adapter, ResponseAdapterABC)
+                else adapter.extract_record(response_data)
+            )
+            if extracted is not None:
+                response_data = extracted
+
         an = "a" if operation == "create" else "an"
         if not isinstance(response_data, dict):
             raise ValueError(

--- a/src/clearskies/configs/__init__.py
+++ b/src/clearskies/configs/__init__.py
@@ -104,6 +104,7 @@ from .path import Path
 from .path_list import PathList
 from .readable_model_column import ReadableModelColumn
 from .readable_model_columns import ReadableModelColumns
+from .response_adapter import ResponseAdapter
 from .schema import Schema
 from .searchable_model_columns import SearchableModelColumns
 from .secret_cache import SecretCache
@@ -164,6 +165,7 @@ __all__ = [
     "PathList",
     "ReadableModelColumn",
     "ReadableModelColumns",
+    "ResponseAdapter",
     "Schema",
     "SearchableModelColumns",
     "SecretCache",

--- a/src/clearskies/configs/response_adapter.py
+++ b/src/clearskies/configs/response_adapter.py
@@ -15,8 +15,9 @@ class ResponseAdapter(config.Config):
     """
     Configuration descriptor that accepts a ``ResponseAdapter`` instance or a callable.
 
-    A ``ResponseAdapter`` subclass provides separate ``extract_records`` and
-    ``extract_record`` hooks for full control over response-envelope unwrapping.
+    A ``ResponseAdapter`` instance (or subclass instance) provides separate
+    ``extract_records`` and ``extract_record`` hooks for response-envelope
+    unwrapping.
 
     A plain callable ``(response_data: Any) -> list | dict | None`` may be
     supplied for simple cases where the same extraction logic covers both list

--- a/src/clearskies/configs/response_adapter.py
+++ b/src/clearskies/configs/response_adapter.py
@@ -1,0 +1,56 @@
+"""Configuration descriptor for ResponseAdapter or callable response extractors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Self, overload
+
+from clearskies.configs import config
+
+if TYPE_CHECKING:
+    from clearskies.backends.adapters import ResponseAdapter as ResponseAdapterType
+
+
+class ResponseAdapter(config.Config):
+    """
+    Configuration descriptor that accepts a ``ResponseAdapter`` instance or a callable.
+
+    A ``ResponseAdapter`` subclass provides separate ``extract_records`` and
+    ``extract_record`` hooks for full control over response-envelope unwrapping.
+
+    A plain callable ``(response_data: Any) -> list | dict | None`` may be
+    supplied for simple cases where the same extraction logic covers both list
+    and single-record responses.
+
+    Example — full adapter::
+
+        backend = clearskies.backends.ApiBackend(
+            base_url="https://api.example.com",
+            response_adapter=MyHalResponseAdapter(),
+        )
+
+    Example — inline callable::
+
+        backend = clearskies.backends.ApiBackend(
+            base_url="https://api.example.com",
+            response_adapter=lambda data: data.get("items"),
+        )
+    """
+
+    def __set__(self, instance: Any, value: ResponseAdapterType | Callable[..., Any] | None) -> None:
+        if value is not None and not hasattr(value, "extract_records") and not callable(value):
+            error_prefix = self._error_prefix(instance)
+            raise TypeError(
+                f"{error_prefix} attempt to set a value of type '{value.__class__.__name__}' to a parameter "
+                "that requires a ResponseAdapter instance or a callable."
+            )
+        instance._set_config(self, value)
+
+    @overload
+    def __get__(self, instance: None, parent: type) -> Self: ...
+    @overload
+    def __get__(self, instance: object, parent: type) -> ResponseAdapterType | Callable[..., Any] | None: ...
+    def __get__(self, instance: Any, parent: type) -> Self | ResponseAdapterType | Callable[..., Any] | None:
+        if not instance:
+            return self
+        return instance._get_config(self)

--- a/tests/backends/test_api_backend.py
+++ b/tests/backends/test_api_backend.py
@@ -114,6 +114,80 @@ class ApiBackendTest(unittest.TestCase):
         assert status_code == 200
         assert payload["data"] == [{"id": 2, "login": "bob"}]
 
+    def test_response_adapter_must_extract_records_when_configured(self):
+        class EmptyAdapter(ResponseAdapter):
+            def extract_records(self, response_data):
+                return None
+
+            def extract_record(self, response_data):
+                return None
+
+        class User(clearskies.Model):
+            id_column_name = "id"
+            backend = clearskies.backends.ApiBackend(
+                base_url="https://api.example.com",
+                response_adapter=EmptyAdapter(),
+            )
+
+            id = clearskies.columns.Integer()
+            login = clearskies.columns.String()
+
+        requests = MagicMock()
+        response = MagicMock()
+        response.ok = True
+        response.headers = {}
+        response.json = MagicMock(
+            return_value={
+                "wrapped": {
+                    "items": [
+                        {"id": "1", "login": "alice"},
+                    ]
+                }
+            }
+        )
+        requests.request = MagicMock(return_value=response)
+
+        context = Context(
+            clearskies.endpoints.List(
+                model_class=User,
+                readable_column_names=["id", "login"],
+                sortable_column_names=["id"],
+                default_sort_column_name=None,
+                default_limit=10,
+            ),
+            classes=[User],
+            bindings={"requests": requests},
+        )
+
+        with self.assertRaises(ValueError) as error:
+            context()
+        assert "response adapter was configured" in str(error.exception)
+
+    def test_response_adapter_must_extract_record_when_configured(self):
+        class EmptyAdapter(ResponseAdapter):
+            def extract_records(self, response_data):
+                return None
+
+            def extract_record(self, response_data):
+                return None
+
+        backend = clearskies.backends.ApiBackend(
+            base_url="https://api.example.com",
+            response_adapter=EmptyAdapter(),
+        )
+        columns: dict[str, clearskies.Column] = {
+            "id": clearskies.columns.Integer(),
+            "login": clearskies.columns.String(),
+        }
+
+        with self.assertRaises(ValueError) as error:
+            backend.map_record_response(
+                response_data={"wrapped": {"item": {"id": "1", "login": "alice"}}},
+                columns=columns,
+                operation="create",
+            )
+        assert "response adapter was configured" in str(error.exception)
+
     def test_overview(self):
         class GithubPublicBackend(clearskies.backends.ApiBackend):
             def __init__(

--- a/tests/backends/test_api_backend.py
+++ b/tests/backends/test_api_backend.py
@@ -2,10 +2,118 @@ import unittest
 from unittest.mock import MagicMock
 
 import clearskies
+from clearskies.backends.adapters import ResponseAdapter
 from clearskies.contexts import Context
 
 
 class ApiBackendTest(unittest.TestCase):
+    def test_response_adapter_from_binding(self):
+        class HalAdapter(ResponseAdapter):
+            def extract_records(self, response_data):
+                return response_data.get("_embedded", {}).get("items")
+
+            def extract_record(self, response_data):
+                return response_data.get("_embedded", {}).get("item")
+
+        class User(clearskies.Model):
+            id_column_name = "id"
+            backend = clearskies.backends.ApiBackend(base_url="https://api.example.com")
+
+            id = clearskies.columns.Integer()
+            login = clearskies.columns.String()
+
+        requests = MagicMock()
+        response = MagicMock()
+        response.ok = True
+        response.headers = {}
+        response.json = MagicMock(
+            return_value={
+                "_embedded": {
+                    "items": [
+                        {"id": "1", "login": "alice"},
+                    ]
+                }
+            }
+        )
+        requests.request = MagicMock(return_value=response)
+
+        context = Context(
+            clearskies.endpoints.List(
+                model_class=User,
+                readable_column_names=["id", "login"],
+                sortable_column_names=["id"],
+                default_sort_column_name=None,
+                default_limit=10,
+            ),
+            classes=[User],
+            bindings={"requests": requests, "response_adapter": HalAdapter()},
+        )
+
+        status_code, payload, _ = context()
+        assert status_code == 200
+        assert payload["data"] == [{"id": 1, "login": "alice"}]
+
+    def test_explicit_response_adapter_beats_binding(self):
+        class ExplicitAdapter(ResponseAdapter):
+            def extract_records(self, response_data):
+                return response_data.get("explicit", {}).get("items")
+
+            def extract_record(self, response_data):
+                return response_data.get("explicit", {}).get("item")
+
+        class BoundAdapter(ResponseAdapter):
+            def extract_records(self, response_data):
+                return response_data.get("bound", {}).get("items")
+
+            def extract_record(self, response_data):
+                return response_data.get("bound", {}).get("item")
+
+        class User(clearskies.Model):
+            id_column_name = "id"
+            backend = clearskies.backends.ApiBackend(
+                base_url="https://api.example.com",
+                response_adapter=ExplicitAdapter(),
+            )
+
+            id = clearskies.columns.Integer()
+            login = clearskies.columns.String()
+
+        requests = MagicMock()
+        response = MagicMock()
+        response.ok = True
+        response.headers = {}
+        response.json = MagicMock(
+            return_value={
+                "explicit": {
+                    "items": [
+                        {"id": "2", "login": "bob"},
+                    ]
+                },
+                "bound": {
+                    "items": [
+                        {"id": "3", "login": "charlie"},
+                    ]
+                },
+            }
+        )
+        requests.request = MagicMock(return_value=response)
+
+        context = Context(
+            clearskies.endpoints.List(
+                model_class=User,
+                readable_column_names=["id", "login"],
+                sortable_column_names=["id"],
+                default_sort_column_name=None,
+                default_limit=10,
+            ),
+            classes=[User],
+            bindings={"requests": requests, "response_adapter": BoundAdapter()},
+        )
+
+        status_code, payload, _ = context()
+        assert status_code == 200
+        assert payload["data"] == [{"id": 2, "login": "bob"}]
+
     def test_overview(self):
         class GithubPublicBackend(clearskies.backends.ApiBackend):
             def __init__(


### PR DESCRIPTION
## Summary

Introduces a composable response-extraction strategy for `ApiBackend` that cleanly separates two distinct concerns:

- **Structural** — *where is the data inside the envelope?* → `ResponseAdapter`
- **Field-level** — *what are the fields called?* → `api_to_model_map` / `map_to_model` (unchanged)

## Changes

### New: `clearskies/backends/adapters/` submodule

| Class | Purpose |
|---|---|
| `ResponseAdapter` | ABC with `extract_records()` and `extract_record()` hooks. Return `None` to fall through to existing `ApiBackend` logic. |
| `DefaultResponseAdapter` | Encapsulates the heuristics previously embedded in `map_records_response`: list passthrough and one-level-deep dict unwrap. |

### New: `clearskies/configs/response_adapter.py`

A `configs.ResponseAdapter` descriptor that accepts either a `ResponseAdapter` instance or a plain callable `(response_data) -> list | dict | None`, following the existing `*OrCallable` pattern.

### Changed: `ApiBackend`

- New `response_adapter` config attribute (default: `DefaultResponseAdapter()`) and matching `__init__` parameter.
- `map_records_response` and `map_record_response` delegate to the adapter before falling through to existing column-aware logic.
- Fully backward compatible — all existing subclasses and usages are unaffected.

### Changed: `clearskies.backends`

Exposes the `adapters` submodule (`clearskies.backends.adapters`), consistent with how `clearskies.columns` and `clearskies.authentication` are structured.

## Usage

```python
# Full adapter — separate logic per operation
from clearskies.backends.adapters import ResponseAdapter

class HalJsonResponseAdapter(ResponseAdapter):
    def extract_records(self, response_data):
        embedded = response_data.get("_embedded", {})
        for value in embedded.values():
            if isinstance(value, list):
                return value
        return None

    def extract_record(self, response_data):
        return response_data.get("_embedded") or None

class HalJsonBackend(clearskies.backends.ApiBackend):
    def __init__(self, **kwargs):
        super().__init__(**kwargs, response_adapter=HalJsonResponseAdapter())
```

```python
# Callable — simple one-liner for both operations
backend = clearskies.backends.ApiBackend(
    base_url="https://api.example.com",
    response_adapter=lambda data: data.get("items"),
)
```