### PR TITLE
feat(auth): JWKS claims validation + configurable descriptor map fix

### DIFF
--- a/docs/python/config.json
+++ b/docs/python/config.json
@@ -253,6 +253,7 @@
             "builder": "clearskies_doc_builder.builders.Module",
             "classes": [
                 "clearskies.authentication.Authorization",
+                "clearskies.authentication.Jwks",
                 "clearskies.authentication.Oauth",
                 "clearskies.authentication.Public",
                 "clearskies.authentication.SecretBearer"

--- a/src/clearskies/authentication/jwks.py
+++ b/src/clearskies/authentication/jwks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from clearskies import configs, decorators, di
 from clearskies.authentication.authentication import Authentication
@@ -14,49 +14,195 @@ if TYPE_CHECKING:
 
 
 class Jwks(Authentication, di.InjectableProperties):
-    """Validate a JWT against a JWKS (JSON Web Key Set)."""
+    """
+    Validate a JWT against a JWKS (JSON Web Key Set).
+
+    This authentication class fetches a set of public keys from a remote JWKS endpoint and uses them
+    to verify the signature of a Bearer token presented in the `Authorization` header.  It is the
+    standard way to validate JWTs issued by OAuth 2.0 / OIDC providers such as Auth0, Azure Active
+    Directory, or any provider that publishes a JWKS document.
+
+    The minimum configuration is a `jwks_url`.  You will typically also want to set `audience` and
+    `issuer` to ensure the token was issued for your application:
+
+    ```python
+    import clearskies
+
+    wsgi = clearskies.contexts.WsgiRef(
+        clearskies.endpoints.Callable(
+            lambda authorization_data: authorization_data,
+            authentication=clearskies.authentication.Jwks(
+                jwks_url="https://auth.example.com/.well-known/jwks.json",
+                audience="https://api.example.com/",
+                issuer="https://auth.example.com/",
+            ),
+        )
+    )
+    wsgi()
+    ```
+
+    Calling the endpoint without a valid token returns a 401:
+
+    ```bash
+    $ curl http://localhost:8080 | jq
+    {
+        "status": "client_error",
+        "error": "Not Authenticated",
+        "data": [],
+        "pagination": {},
+        "input_errors": {}
+    }
+    ```
+
+    With a valid Bearer token the decoded JWT payload is available via the `authorization_data`
+    dependency:
+
+    ```bash
+    $ curl http://localhost:8080 -H "Authorization: Bearer <token>" | jq
+    {
+        "status": "success",
+        "error": "",
+        "data": {
+            "sub": "example-user",
+            "iss": "https://auth.example.com/",
+            "aud": "https://api.example.com/"
+        },
+        "pagination": {},
+        "input_errors": {}
+    }
+    ```
+    """
 
     """
-    The URL of the JWKS
+    The URL from which to fetch the JSON Web Key Set.
 
-    When authenticating a request coming in to an endpoint, clearskies will fetch the JWKS from this URL
-    and use the public keys to validate the JWT presented by the client.
+    clearskies fetches this URL to retrieve the public keys used to verify incoming JWTs.  The
+    response must be a standard JWKS document — a JSON object with a `keys` array.  Key selection
+    is performed automatically by matching the `kid` header of the incoming token against the keys
+    in the set.
+
+    The key set is cached for `jwks_cache_time` seconds (default one day) to avoid a remote fetch
+    on every request.
     """
     jwks_url = configs.String(required=True)
 
     """
     The audience to accept JWTs for.
 
-    If provided, JWTs will be rejected if their `aud` claim doesn't exactly match the value given here.
-    If you do not provide an audience, then all audiences will be accepted.
+    If provided, JWTs will be rejected unless their `aud` claim contains this value.  You should
+    always set this to the identifier of your own API to prevent tokens issued for other services
+    from being accepted.  If you do not provide an audience then all audiences will be accepted.
     """
     audience = configs.String(default="")
 
     """
     The expected issuer of the JWTs.
 
-    If provided, JWTs will be rejected if their `iss` claim doesn't exactly match the value given here.
-    If you do not provide an issuer, then all audiences will be accepted.
+    If provided, JWTs will be rejected unless their `iss` claim exactly matches this value.  Set
+    this to the base URL of the authorization server that issues tokens for your application.  If
+    you do not provide an issuer then any issuer will be accepted.
     """
     issuer = configs.String(default="")
 
     """
-    The allowed algorithms.
+    The allowed signing algorithms.
+
+    Passed directly to `jwcrypto.jwt.JWT(algs=...)`.  Any token whose `alg` header is not in this
+    list is rejected before signature verification.  An empty list disables the restriction; any
+    algorithm that is cryptographically compatible with the matched JWKS key is then accepted.
     """
     algorithms = configs.StringList(default=["RS256"])
 
     """
     The number of seconds for which the JWKS URL contents can be cached.
+
+    Defaults to 86400 (one day).  Set to 0 to disable caching and always fetch fresh keys.
     """
     jwks_cache_time = configs.Integer(default=86400)
 
     """
-    The Authorization URL (used in the auto-generated documentation)
+    The authorization URL used in the auto-generated API documentation.
+
+    This value is only used when generating OpenAPI documentation and has no effect on
+    authentication behaviour at runtime.
     """
     authorization_url = configs.String()
 
     """
-    The name of the security scheme in the auto-generated documentation.
+    Additional claim validation applied after the JWT signature is verified.
+
+    Provide a list of claim names to require their presence in the decoded payload.  A 401
+    is returned if any listed claim is missing:
+
+    ```python
+    import clearskies
+
+    wsgi = clearskies.contexts.WsgiRef(
+        clearskies.endpoints.Callable(
+            lambda: {"hello": "world"},
+            authentication=clearskies.authentication.Jwks(
+                jwks_url="https://example.com/.well-known/jwks.json",
+                claims=["role", "sub"],
+            ),
+        )
+    )
+    wsgi()
+    ```
+
+    For custom logic, provide a callable instead.  The clearskies DI system injects `jwt_claims`
+    (the decoded payload as a dict) plus any other name resolvable from the DI container, so only
+    declare the parameters your function actually needs.
+
+    The callable may return `True` or `None` to accept the token, `False` to reject it with a 401,
+    or a list of strings to dynamically specify which claims must be present:
+
+    ```python
+    import clearskies
+
+    def no_blocked_users(jwt_claims):
+        return "blocked" not in jwt_claims
+
+    wsgi = clearskies.contexts.WsgiRef(
+        clearskies.endpoints.Callable(
+            lambda: {"hello": "world"},
+            authentication=clearskies.authentication.Jwks(
+                jwks_url="https://example.com/.well-known/jwks.json",
+                claims=no_blocked_users,
+            ),
+        )
+    )
+    wsgi()
+    ```
+
+    You can also return a dynamic list of required claims based on the payload:
+
+    ```python
+    import clearskies
+
+    def require_extra_claims_for_admins(jwt_claims):
+        if jwt_claims.get("role") == "admin":
+            return ["department", "employee_id"]
+        return True
+
+    wsgi = clearskies.contexts.WsgiRef(
+        clearskies.endpoints.Callable(
+            lambda: {"hello": "world"},
+            authentication=clearskies.authentication.Jwks(
+                jwks_url="https://example.com/.well-known/jwks.json",
+                claims=require_extra_claims_for_admins,
+            ),
+        )
+    )
+    wsgi()
+    ```
+    """
+    claims = configs.StringListOrCallable(default=[])
+
+    """
+    The name of the security scheme in the auto-generated API documentation.
+
+    Defaults to `jwt`.  Override this if your documentation needs to distinguish between multiple
+    JWT-based authentication schemes on the same set of endpoints.
     """
     documentation_security_name = configs.String(default="jwt")
 
@@ -71,17 +217,22 @@ class Jwks(Authentication, di.InjectableProperties):
     requests = di.inject.Requests()
 
     """
-    The current time
+    The current time.
     """
     now = di.inject.Now()
 
     """
-    Local cache of the JWKS
+    The dependency injection container.
+    """
+    di = di.inject.Di()
+
+    """
+    Local cache of the JWKS.
     """
     _jwks = None
 
     """
-    The time when the JWKS was last fetched
+    The time when the JWKS was last fetched.
     """
     _jwks_fetched: datetime.datetime
 
@@ -94,6 +245,7 @@ class Jwks(Authentication, di.InjectableProperties):
         algorithms: list[str] = ["RS256"],
         jwks_cache_time: int = 86400,
         authorization_url: str = "",
+        claims: list[str] | Callable[..., list[str] | bool | None] | None = None,
         documentation_security_name: str = "jwt",
     ):
         self.finalize_and_validate_configuration()
@@ -108,7 +260,7 @@ class Jwks(Authentication, di.InjectableProperties):
         input_output.authorization_data = self.jwt_claims
         return True
 
-    def validate_jwt(self, raw_jwt):
+    def validate_jwt(self, raw_jwt: str) -> bool:
         try:
             from jwcrypto import jwk, jwt
             from jwcrypto.common import JWException
@@ -117,14 +269,17 @@ class Jwks(Authentication, di.InjectableProperties):
                 "The JWKS authentication method requires the jwcrypto library to be installed.  This is an optional dependency of clearskies, so to include it do a `pip install 'clear-skies[jwcrypto]'`"
             )
 
-        keys = jwk.JWKSet()
-        keys.import_keyset(json.dumps(self._get_jwks()))
-
-        client_jwt = jwt.JWT()
+        # Fail fast on malformed token before touching the JWKS endpoint.
+        client_jwt = jwt.JWT(algs=self.algorithms or None)
         try:
             client_jwt.deserialize(raw_jwt)
         except Exception as e:
             raise ClientError(str(e))
+
+        # kid-based key selection and cryptographic verification are handled by jwcrypto.
+        # Passing the full JWKSet lets it pick the matching key by kid automatically.
+        keys = jwk.JWKSet()
+        keys.import_keyset(json.dumps(self._get_jwks()))
 
         try:
             client_jwt.validate(keys)
@@ -139,14 +294,43 @@ class Jwks(Authentication, di.InjectableProperties):
             jwt_audience = self.jwt_claims.get("aud")
             if not jwt_audience:
                 raise ClientError("Audience required, but missing in JWT")
-            has_match = False
-            for audience in jwt_audience:
-                if audience == self.audience:
-                    has_match = True
-            if not has_match:
+            if isinstance(jwt_audience, str):
+                jwt_audiences = [jwt_audience]
+            elif isinstance(jwt_audience, list):
+                jwt_audiences = jwt_audience
+            else:
+                raise ClientError("Audience claim has invalid format")
+            if self.audience not in jwt_audiences:
                 raise ClientError("Audience does not match")
 
+        self.validate_claims()
+
         return True
+
+    def validate_claims(self) -> None:
+        claims = self.claims
+        if not claims:
+            return
+
+        if callable(claims):
+            result = self.di.call_function(
+                claims,
+                jwt_claims=self.jwt_claims,
+            )
+            if result is None or result is True:
+                return
+            if result is False:
+                raise ClientError("JWT claims failed custom validation")
+            if not isinstance(result, list):
+                raise TypeError("claims callable must return a list, bool, or None")
+            claims = result
+
+        if not claims:
+            return
+
+        for claim in claims:
+            if claim not in self.jwt_claims:
+                raise ClientError(f"Required claim missing: {claim}")
 
     def _get_jwks(self):
         if self._jwks is None or ((self.now - self._jwks_fetched).total_seconds() > self.jwks_cache_time):

--- a/src/clearskies/authentication/oauth.py
+++ b/src/clearskies/authentication/oauth.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from clearskies.secrets import Secrets
 
 
-class Oauth(Jwks, di.InjectableProperties):
+class Oauth(Jwks):
     """
     Perform authentication for incoming and outgoing requests in an Oauth context.
 

--- a/src/clearskies/configurable.py
+++ b/src/clearskies/configurable.py
@@ -32,8 +32,9 @@ class Configurable:
 
     @classmethod
     def get_descriptor_config_map(cls) -> dict[int, str]:
-        if cls._descriptor_config_map:
-            return cls._descriptor_config_map
+        own_map = cls.__dict__.get("_descriptor_config_map")
+        if own_map:
+            return own_map
 
         descriptor_config_map: dict[int, str] = {}
         for attribute_name in dir(cls):

--- a/tests/authentication/test_jwks.py
+++ b/tests/authentication/test_jwks.py
@@ -1,0 +1,341 @@
+import base64
+import datetime
+import json
+import types
+import unittest
+from types import SimpleNamespace
+from typing import Any, Callable, cast
+from unittest.mock import MagicMock, patch
+
+import clearskies
+from clearskies.di.di import Di
+from clearskies.exceptions import ClientError
+
+
+class FakeJWException(Exception):
+    pass
+
+
+class FakeJWKSet:
+    def import_keyset(self, raw_json: str) -> None:
+        self.keyset = json.loads(raw_json)
+
+
+class FakeJWT:
+    """
+    Minimal stand-in for jwcrypto.jwt.JWT.
+
+    Mirrors the real class closely enough for unit tests:
+    - accepts ``algs`` in the constructor (as the real JWT does)
+    - ``deserialize`` parses the header from the raw token and stores it as a
+      JSON string on ``self.header``, exactly as jwcrypto does
+    - ``validate`` always succeeds so tests can focus on our own logic
+    """
+
+    def __init__(self, algs: list[str] | None = None) -> None:
+        self.algs = algs
+        self.header: str = "{}"
+        self.claims_data: dict[str, Any] = {
+            "iss": "https://issuer.example.com",
+            "aud": ["https://audience.example.com"],
+            "scope": "read",
+        }
+
+    def deserialize(self, raw_jwt: str) -> None:
+        parts = raw_jwt.split(".")
+        if len(parts) == 3:
+            encoded = parts[0] + "=" * (-len(parts[0]) % 4)
+            header_dict = json.loads(base64.urlsafe_b64decode(encoded))
+            self.header = json.dumps(header_dict)
+        else:
+            self.header = "{}"
+        self.claims = json.dumps(self.claims_data)
+
+    def validate(self, _keys: FakeJWKSet) -> None:
+        return None
+
+
+def _build_jwt(header: dict[str, str], payload: dict[str, str] | None = None) -> str:
+    payload = payload or {"sub": "example-user"}
+    encoded_header = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+    encoded_payload = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"{encoded_header}.{encoded_payload}.signature"
+
+
+def _mock_jwcrypto_modules(claims_data: dict[str, Any] | None = None) -> dict[str, types.ModuleType]:
+    """Return mocked jwcrypto modules.  Pass ``claims_data`` to override the decoded JWT payload."""
+    effective_claims = (
+        claims_data
+        if claims_data is not None
+        else {
+            "iss": "https://issuer.example.com",
+            "aud": ["https://audience.example.com"],
+            "scope": "read",
+        }
+    )
+
+    class _JWT(FakeJWT):
+        def __init__(self, algs: list[str] | None = None) -> None:
+            super().__init__(algs)
+            self.claims_data = dict(effective_claims)
+
+    jwk_module = types.ModuleType("jwcrypto.jwk")
+    setattr(jwk_module, "JWKSet", FakeJWKSet)
+
+    jwt_module = types.ModuleType("jwcrypto.jwt")
+    setattr(jwt_module, "JWT", _JWT)
+
+    common_module = types.ModuleType("jwcrypto.common")
+    setattr(common_module, "JWException", FakeJWException)
+
+    jwcrypto_module = types.ModuleType("jwcrypto")
+    setattr(jwcrypto_module, "jwk", jwk_module)
+    setattr(jwcrypto_module, "jwt", jwt_module)
+
+    return {
+        "jwcrypto": jwcrypto_module,
+        "jwcrypto.jwk": jwk_module,
+        "jwcrypto.jwt": jwt_module,
+        "jwcrypto.common": common_module,
+    }
+
+
+_DEFAULT_JWKS = {"keys": [{"kid": "key-1", "alg": "RS256", "kty": "RSA", "n": "abc", "e": "AQAB"}]}
+_DEFAULT_RAW_JWT = _build_jwt({"alg": "RS256", "kid": "key-1"})
+
+
+class TestJwks(unittest.TestCase):
+    def _authentication(
+        self,
+        claims: list[str] | Callable[..., Any] | None = None,
+        algorithms: list[str] = ["RS256"],
+        issuer: str = "https://issuer.example.com",
+        audience: str = "https://audience.example.com",
+    ) -> clearskies.authentication.Jwks:
+        authentication = clearskies.authentication.Jwks(
+            jwks_url="https://example.com/.well-known/jwks.json",
+            issuer=issuer,
+            audience=audience,
+            claims=claims,
+            algorithms=algorithms,
+        )
+        authentication.injectable_properties(Di())
+        return authentication
+
+    # --- authenticate ---
+
+    def test_authenticate_rejects_missing_authorization_header(self):
+        authentication = self._authentication()
+        io = SimpleNamespace(request_headers={})
+        with self.assertRaisesRegex(ClientError, "Missing 'Authorization' header in request"):
+            authentication.authenticate(cast(Any, io))
+
+    def test_authenticate_rejects_wrong_header_prefix(self):
+        authentication = self._authentication()
+        io = SimpleNamespace(request_headers={"authorization": "Token abc123"})
+        with self.assertRaisesRegex(ClientError, "Missing 'Bearer ' prefix in authorization header"):
+            authentication.authenticate(cast(Any, io))
+
+    def test_authenticate_sets_authorization_data_on_success(self):
+        authentication = self._authentication()
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        io = SimpleNamespace(request_headers={"authorization": f"Bearer {_DEFAULT_RAW_JWT}"}, authorization_data=None)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            result = authentication.authenticate(cast(Any, io))
+        self.assertTrue(result)
+        self.assertEqual("https://issuer.example.com", io.authorization_data.get("iss"))
+
+    # --- Format validation: uses real jwcrypto, no JWKS call needed ---
+
+    def test_validate_jwt_rejects_malformed_token(self):
+        authentication = self._authentication()
+        with self.assertRaises(ClientError):
+            authentication.validate_jwt("only.two")
+
+    # --- Issuer validation ---
+
+    def test_validate_jwt_rejects_wrong_issuer(self):
+        authentication = self._authentication()
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict(
+            "sys.modules",
+            _mock_jwcrypto_modules(
+                claims_data={"iss": "https://wrong.example.com", "aud": ["https://audience.example.com"]}
+            ),
+        ):
+            with self.assertRaisesRegex(ClientError, "Issuer does not match"):
+                authentication.validate_jwt(_DEFAULT_RAW_JWT)
+
+    def test_validate_jwt_accepts_matching_issuer(self):
+        authentication = self._authentication()
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            self.assertTrue(authentication.validate_jwt(_DEFAULT_RAW_JWT))
+
+    # --- Audience validation ---
+
+    def test_validate_jwt_rejects_when_aud_claim_missing(self):
+        authentication = self._authentication()
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules(claims_data={"iss": "https://issuer.example.com"})):
+            with self.assertRaisesRegex(ClientError, "Audience required, but missing in JWT"):
+                authentication.validate_jwt(_DEFAULT_RAW_JWT)
+
+    def test_validate_jwt_rejects_wrong_audience(self):
+        authentication = self._authentication()
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict(
+            "sys.modules",
+            _mock_jwcrypto_modules(
+                claims_data={"iss": "https://issuer.example.com", "aud": ["https://other.example.com"]}
+            ),
+        ):
+            with self.assertRaisesRegex(ClientError, "Audience does not match"):
+                authentication.validate_jwt(_DEFAULT_RAW_JWT)
+
+    def test_validate_jwt_accepts_audience_as_string(self):
+        authentication = self._authentication()
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict(
+            "sys.modules",
+            _mock_jwcrypto_modules(
+                claims_data={"iss": "https://issuer.example.com", "aud": "https://audience.example.com"}
+            ),
+        ):
+            self.assertTrue(authentication.validate_jwt(_DEFAULT_RAW_JWT))
+
+    def test_validate_jwt_accepts_audience_in_list(self):
+        authentication = self._authentication()
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            self.assertTrue(authentication.validate_jwt(_DEFAULT_RAW_JWT))
+
+    # --- claims validation ---
+
+    def test_validate_jwt_accepts_token_when_no_claims_configured(self):
+        authentication = self._authentication()
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            self.assertTrue(authentication.validate_jwt(_DEFAULT_RAW_JWT))
+
+    def test_validate_jwt_rejects_missing_required_claim_from_list(self):
+        authentication = self._authentication(claims=["role"])
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            with self.assertRaisesRegex(ClientError, "Required claim missing: role"):
+                authentication.validate_jwt(_DEFAULT_RAW_JWT)
+
+    def test_validate_jwt_accepts_token_when_all_required_claims_present(self):
+        authentication = self._authentication(claims=["iss", "scope"])
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            self.assertTrue(authentication.validate_jwt(_DEFAULT_RAW_JWT))
+
+    def test_validate_jwt_callable_returning_true_accepts_token(self):
+        def check_claims(jwt_claims: dict[str, Any]) -> bool:
+            return "forbidden" not in jwt_claims
+
+        authentication = self._authentication(claims=check_claims)
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            self.assertTrue(authentication.validate_jwt(_DEFAULT_RAW_JWT))
+
+    def test_validate_jwt_callable_returning_none_accepts_token(self):
+        def check_claims(jwt_claims: dict[str, Any]) -> None:
+            return None
+
+        authentication = self._authentication(claims=check_claims)
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            self.assertTrue(authentication.validate_jwt(_DEFAULT_RAW_JWT))
+
+    def test_validate_jwt_callable_returning_false_rejects_token(self):
+        def check_claims(jwt_claims: dict[str, Any]) -> bool:
+            return "scope" not in jwt_claims
+
+        authentication = self._authentication(claims=check_claims)
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            with self.assertRaisesRegex(ClientError, "JWT claims failed custom validation"):
+                authentication.validate_jwt(_DEFAULT_RAW_JWT)
+
+    def test_validate_jwt_callable_returning_list_enforces_those_claims(self):
+        def check_claims(jwt_claims: dict[str, Any]) -> list[str]:
+            return ["role"]  # always require 'role', which is absent from FakeJWT claims
+
+        authentication = self._authentication(claims=check_claims)
+        setattr(authentication, "_get_jwks", lambda: _DEFAULT_JWKS)
+        with patch.dict("sys.modules", _mock_jwcrypto_modules()):
+            with self.assertRaisesRegex(ClientError, "Required claim missing: role"):
+                authentication.validate_jwt(_DEFAULT_RAW_JWT)
+
+    # --- _get_jwks caching ---
+
+    def test_get_jwks_fetches_from_url(self):
+        authentication = self._authentication()
+        requests_mock = MagicMock()
+        requests_mock.get.return_value.json.return_value = _DEFAULT_JWKS
+        setattr(authentication, "requests", requests_mock)
+        setattr(authentication, "now", datetime.datetime(2024, 1, 1))
+
+        result = authentication._get_jwks()
+
+        requests_mock.get.assert_called_once_with("https://example.com/.well-known/jwks.json")
+        self.assertEqual(_DEFAULT_JWKS, result)
+        self.assertEqual(_DEFAULT_JWKS, authentication._jwks)
+
+    def test_get_jwks_returns_cached_result_within_cache_time(self):
+        authentication = self._authentication()
+        requests_mock = MagicMock()
+        setattr(authentication, "requests", requests_mock)
+        setattr(authentication, "now", datetime.datetime(2024, 1, 1, 12, 0, 0))
+        authentication._jwks = _DEFAULT_JWKS
+        authentication._jwks_fetched = datetime.datetime(2024, 1, 1, 11, 0, 0)  # 1 hour ago, within 24h
+
+        result = authentication._get_jwks()
+
+        requests_mock.get.assert_not_called()
+        self.assertEqual(_DEFAULT_JWKS, result)
+
+    def test_get_jwks_refetches_after_cache_expiry(self):
+        authentication = self._authentication()
+        fresh_jwks = {"keys": [{"kid": "key-2", "alg": "RS256"}]}
+        requests_mock = MagicMock()
+        requests_mock.get.return_value.json.return_value = fresh_jwks
+        setattr(authentication, "requests", requests_mock)
+        setattr(authentication, "now", datetime.datetime(2024, 1, 2, 12, 0, 0))
+        authentication._jwks = _DEFAULT_JWKS
+        authentication._jwks_fetched = datetime.datetime(2024, 1, 1, 11, 0, 0)  # 25 hours ago
+
+        result = authentication._get_jwks()
+
+        requests_mock.get.assert_called_once()
+        self.assertEqual(fresh_jwks, result)
+
+    # --- documentation helpers ---
+
+    def test_documentation_security_scheme_returns_oauth2_structure(self):
+        authentication = clearskies.authentication.Jwks(
+            jwks_url="https://example.com/.well-known/jwks.json",
+            authorization_url="https://auth.example.com/authorize",
+        )
+        scheme = authentication.documentation_security_scheme()
+        self.assertEqual("oauth2", scheme["type"])
+        self.assertEqual("https://auth.example.com/authorize", scheme["flows"]["implicit"]["authorizationUrl"])
+
+    def test_documentation_security_scheme_name_defaults_to_jwt(self):
+        authentication = clearskies.authentication.Jwks(jwks_url="https://example.com/.well-known/jwks.json")
+        self.assertEqual("jwt", authentication.documentation_security_scheme_name())
+
+    def test_documentation_security_scheme_name_respects_override(self):
+        authentication = clearskies.authentication.Jwks(
+            jwks_url="https://example.com/.well-known/jwks.json",
+            documentation_security_name="my_scheme",
+        )
+        self.assertEqual("my_scheme", authentication.documentation_security_scheme_name())
+
+    def test_set_headers_for_cors_adds_authorization(self):
+        authentication = self._authentication()
+        cors_mock = MagicMock()
+        authentication.set_headers_for_cors(cors_mock)
+        cors_mock.add_header.assert_called_once_with("Authorization")


### PR DESCRIPTION
## What

Extends the `Jwks` authentication class with a `claims` config for post-signature claim validation, simplifies JWT validation by delegating more to jwcrypto, and fixes a latent inheritance bug in the configurable descriptor map cache.

---

### `Jwks`: new `claims` config

Accepts a list of required claim names or a callable for custom validation logic.

**List form** — rejects the request if any listed claim is absent from the decoded payload:
```python
clearskies.authentication.Jwks(
    jwks_url="https://auth.example.com/.well-known/jwks.json",
    claims=["role", "sub"],
)
```

**Callable form** — the DI system injects `jwt_claims` (and any other DI-resolvable name) so you only declare what you need. Returns `True`/`None` to accept, `False` to reject, or a `list[str]` to enforce presence of those claims:
```python
def no_blocked_users(jwt_claims):
    return "blocked" not in jwt_claims

clearskies.authentication.Jwks(
    jwks_url="https://auth.example.com/.well-known/jwks.json",
    claims=no_blocked_users,
)
```

---

### `Jwks`: simplified JWT validation

Removed manual base64 header parsing and all pre-checks that duplicated what jwcrypto already does:

- `kid`-based key selection — jwcrypto's `validate(JWKSet)` handles this natively
- Algorithm enforcement — delegated to `jwt.JWT(algs=self.algorithms)`
- Token format validation — jwcrypto's `deserialize` raises for malformed tokens

---

### `configurable.get_descriptor_config_map` — bug fix

`get_descriptor_config_map` used `cls._descriptor_config_map` which follows MRO. Once a parent class (e.g. `Jwks`) built and cached its map, subclasses (`Oauth`) would find it through inheritance and return it without building their own — making the subclass's own descriptors invisible at runtime.

Fixed by checking `cls.__dict__.get("_descriptor_config_map")` instead, which only looks at the map owned directly by `cls`. The `_descriptor_config_map = None` workaround in subclasses is now unnecessary.

---

### Documentation

All `Jwks` config properties now have full docstrings in the `endpoint.py` style — prose explaining what the config does and why to set it, with runnable code examples. The class docstring includes a full setup example and example curl output.

---

### Tests (`tests/authentication/test_jwks.py`)

New test file covering:

- `authenticate`: missing `Authorization` header, wrong `Bearer` prefix, successful auth setting `authorization_data`
- Issuer validation: mismatch rejected, match accepted
- Audience validation: missing claim, wrong value, string form, list form
- `claims` list: missing claim rejected, all present accepted
- `claims` callable: `True`, `False`, `None`, and `list[str]` return values
- `_get_jwks`: initial fetch from URL, cache hit within TTL, refetch after expiry
- Documentation helpers: `documentation_security_scheme`, `documentation_security_scheme_name`, `set_headers_for_cors`