### PR TITLE
feat(backends): add HalJsonResponseAdapter and JsonApiResponseAdapter

### DIFF
--- a/src/clearskies/backends/adapters/__init__.py
+++ b/src/clearskies/backends/adapters/__init__.py
@@ -1,7 +1,11 @@
 """Response adapters for ApiBackend response-envelope extraction."""
 
 from clearskies.backends.adapters.response_adapter import ResponseAdapter
+from clearskies.backends.adapters.hal_json_response_adapter import HalJsonResponseAdapter
+from clearskies.backends.adapters.json_api_response_adapter import JsonApiResponseAdapter
 
 __all__ = [
     "ResponseAdapter",
+    "HalJsonResponseAdapter",
+    "JsonApiResponseAdapter",
 ]

--- a/src/clearskies/backends/adapters/hal_json_response_adapter.py
+++ b/src/clearskies/backends/adapters/hal_json_response_adapter.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import ResponseAdapter
+
+
+class HalJsonResponseAdapter(ResponseAdapter):
+    """
+    Unwrap `HAL+JSON <https://stateless.group/hal_specification.html>`_ response envelopes for ``ApiBackend``.
+
+    HAL (Hypertext Application Language) is a widely-adopted convention for embedding hypermedia
+    controls in JSON APIs.  A typical HAL list response looks like this:
+
+    ```json
+    {
+        "_links": {"self": {"href": "/articles"}},
+        "_embedded": {
+            "articles": [
+                {
+                    "id": 1,
+                    "title": "Hello World",
+                    "_links": {"self": {"href": "/articles/1"}}
+                }
+            ]
+        }
+    }
+    ```
+
+    Without an adapter, ``ApiBackend`` has no way to know that the real records are buried inside
+    ``_embedded.articles``.  ``HalJsonResponseAdapter`` navigates that nesting automatically and
+    delivers a clean list of plain dicts to the model's column-mapping layer:
+
+    ```json
+    [{"id": 1, "title": "Hello World"}]
+    ```
+
+    ## Supported envelope shapes
+
+    The adapter handles a broad range of real-world payload shapes in priority order:
+
+    1. **Idiomatic HAL** — ``_embedded`` wrapping a list or a named sub-resource.
+    2. **Named list containers** — top-level keys such as ``"items"``, ``"results"``, ``"data"``
+       (see :attr:`list_container_keys`).
+    3. **Bare list** — a JSON array at the root is returned as-is.
+    4. **Key→record map** — a dict whose non-metadata values are all dicts is treated as a named
+       record collection; the key is injected as ``"key"`` into each record.
+    5. **Recursive fallback** — any nested value that contains a list is unwrapped.
+
+    For single-record extraction the adapter checks :attr:`record_container_keys` first, then
+    ``_embedded``, and finally returns the entire response dict as a last resort (useful for APIs
+    that return a bare object with no wrapper key).
+
+    ## Normalisation
+
+    :meth:`_normalize_record` removes keys listed in :attr:`metadata_keys` (``"_links"`` by
+    default) and promotes ``_embedded`` sub-resources from each record to the top level.  Existing
+    top-level keys are never overwritten by embedded content.
+
+    Note that ``_links`` is only stripped from **individual record objects** inside the list, not
+    from the top-level response envelope.  ``ApiBackend`` drives pagination from HTTP response
+    headers (the ``Link`` header and ``X-Total-Count``), so the top-level ``_links`` body field is
+    never needed by the framework.  If you subclass ``ApiBackend`` and override
+    ``get_next_page_data_from_response`` to read ``_links`` from the JSON body, that data is
+    still available on the raw ``response.json()`` call — the adapter does not touch it.
+
+    ## Full working example
+
+    Define a backend subclass that points at the upstream HAL service and attach the adapter,
+    then wire it into a model and expose it through a list endpoint:
+
+    ```python
+    import clearskies
+
+
+    class ArticleBackend(clearskies.backends.ApiBackend):
+        def __init__(self):
+            super().__init__(
+                base_url="https://hal.example.com",
+                response_adapter=clearskies.backends.adapters.HalJsonResponseAdapter(),
+            )
+
+
+    class Article(clearskies.Model):
+        id_column_name = "id"
+        backend = ArticleBackend()
+
+        id = clearskies.columns.Integer()
+        title = clearskies.columns.String()
+
+
+    wsgi = clearskies.contexts.WsgiRef(
+        clearskies.endpoints.List(
+            model_class=Article,
+            readable_column_names=["id", "title"],
+            sortable_column_names=["id"],
+            default_sort_column_name=None,
+            default_limit=10,
+        ),
+        classes=[Article],
+    )
+    wsgi()
+    ```
+
+    Assuming ``https://hal.example.com/articles`` returns a HAL envelope, the endpoint unwraps
+    it transparently:
+
+    ```bash
+    $ curl 'http://localhost:8080/' | jq
+    {
+        "status": "success",
+        "error": "",
+        "data": [
+            {"id": 1, "title": "Hello"},
+            {"id": 2, "title": "World"}
+        ],
+        "pagination": {"number_results": 2, "limit": 10, "next_page": {}},
+        "input_errors": {}
+    }
+    ```
+
+    ## Customising the adapter
+
+    All lookup keys are defined as class attributes so that subclasses can extend or replace them
+    without overriding any logic:
+
+    ```python
+    from clearskies.backends.adapters import HalJsonResponseAdapter
+
+
+    class MyHalAdapter(HalJsonResponseAdapter):
+        # Add "entries" as an additional list container key.
+        list_container_keys = HalJsonResponseAdapter.list_container_keys + ("entries",)
+
+        # Also strip "_meta" from each normalised record.
+        metadata_keys = HalJsonResponseAdapter.metadata_keys + ("_meta",)
+    ```
+
+    ## Binding the adapter via DI
+
+    You can register the adapter in the dependency injection container instead of setting it on
+    the backend instance:
+
+    ```python
+    context = clearskies.contexts.WsgiRef(
+        clearskies.endpoints.List(model_class=Article, ...),
+        bindings={"response_adapter": HalJsonResponseAdapter()},
+    )
+    ```
+
+    An adapter set directly on the backend always takes precedence over one registered via DI.
+    """
+
+    """
+    Top-level dict keys that indicate the value is a list of records.
+
+    The adapter checks these keys in order and recurses into the first match.  Extend this tuple
+    in a subclass to support additional envelope conventions without overriding any logic:
+
+    ```python
+    from clearskies.backends.adapters import HalJsonResponseAdapter
+
+    class MyAdapter(HalJsonResponseAdapter):
+        list_container_keys = HalJsonResponseAdapter.list_container_keys + ("entries", "rows")
+    ```
+    """
+    list_container_keys = ("items", "results", "records", "data", "content", "values", "paths")
+
+    """
+    Top-level dict keys that indicate the value is a single record.
+
+    Checked in order inside :meth:`_find_record`.  The first key whose value is a dict is
+    returned as the record.  Extend in a subclass to add custom key names:
+
+    ```python
+    from clearskies.backends.adapters import HalJsonResponseAdapter
+
+    class MyAdapter(HalJsonResponseAdapter):
+        record_container_keys = HalJsonResponseAdapter.record_container_keys + ("payload",)
+    ```
+    """
+    record_container_keys = ("item", "result", "record", "data")
+
+    """
+    Keys that carry HAL metadata and should be stripped from normalised records.
+
+    By default only ``"_links"`` is removed.  Override in a subclass to also strip ``"_meta"``,
+    ``"_curies"``, or any other envelope-level key:
+
+    ```python
+    from clearskies.backends.adapters import HalJsonResponseAdapter
+
+    class MyAdapter(HalJsonResponseAdapter):
+        metadata_keys = ("_links", "_meta", "_curies")
+    ```
+    """
+    metadata_keys = ("_links",)
+
+    # Keys that are structurally part of HAL and are excluded from the key→record-map heuristic.
+    # This prevents a response like {"_links": {"self": {...}}, "_embedded": {...}} from being
+    # misidentified as a named record collection.
+    _hal_structural_keys = frozenset(("_links", "_embedded", "_meta", "_curies", "_page"))
+
+    def extract_records(self, response_data: Any) -> list[dict[str, Any]] | None:
+        """Return a normalised list of records located anywhere inside the HAL payload.
+
+        Returns ``None`` to hand control back to the built-in ``ApiBackend`` extraction logic when
+        no list of dicts can be found.
+        """
+        records = self._find_records(response_data)
+        if records is None:
+            return None
+        return [self._normalize_record(record) for record in records]
+
+    def extract_record(self, response_data: Any) -> dict[str, Any] | None:
+        """Return a single normalised record located anywhere inside the HAL payload.
+
+        Returns ``None`` to hand control back to the built-in ``ApiBackend`` extraction logic when
+        no suitable dict can be found.
+        """
+        record = self._find_record(response_data)
+        if record is None:
+            return None
+        return self._normalize_record(record)
+
+    def _find_records(self, response_data: Any) -> list[dict[str, Any]] | None:
+        """Locate the list of raw record dicts inside *response_data*.
+
+        Checks in order: bare list, ``_embedded``, :attr:`list_container_keys`, key→record-map
+        heuristic (non-structural dict values that are all dicts), then a recursive depth-first
+        scan of remaining values.  Returns ``None`` if no list of dicts is found.
+        """
+        if isinstance(response_data, list):
+            if all(isinstance(item, dict) for item in response_data):
+                return response_data
+            return None
+
+        if not isinstance(response_data, dict):
+            return None
+
+        # 1. Idiomatic HAL: _embedded → first list-valued entry.
+        embedded = response_data.get("_embedded")
+        if isinstance(embedded, dict):
+            for value in embedded.values():
+                found = self._find_records(value)
+                if found is not None:
+                    return found
+
+        # 2. Named list containers (items, results, data, …).
+        for key in self.list_container_keys:
+            if key in response_data:
+                found = self._find_records(response_data[key])
+                if found is not None:
+                    return found
+
+        # 3. Key→record-map heuristic: every *non-structural* value is a dict.
+        #    Structural HAL keys (_links, _embedded, …) are excluded so that a
+        #    response like {"_links": {"self": {…}}, "_embedded": {…}} is NOT
+        #    misidentified as a named record collection.
+        non_structural = {k: v for k, v in response_data.items() if k not in self._hal_structural_keys}
+        if non_structural and all(isinstance(v, dict) for v in non_structural.values()):
+            dict_records: list[dict[str, Any]] = []
+            for key, value in non_structural.items():
+                record = {**value}
+                record.setdefault("key", key)
+                dict_records.append(record)
+            return dict_records
+
+        # 4. Recursive fallback: scan remaining values depth-first.
+        for value in response_data.values():
+            found = self._find_records(value)
+            if found is not None:
+                return found
+
+        return None
+
+    def _find_record(self, response_data: Any) -> dict[str, Any] | None:
+        """Locate a single raw record dict inside *response_data*.
+
+        Checks in order: first dict in a list, :attr:`record_container_keys`, ``_embedded``, and
+        finally the entire response dict as a last resort for bare-object APIs.
+        """
+        if isinstance(response_data, list):
+            for item in response_data:
+                if isinstance(item, dict):
+                    return item
+            return None
+
+        if not isinstance(response_data, dict):
+            return None
+
+        # Named record containers take priority.
+        for key in self.record_container_keys:
+            value = response_data.get(key)
+            if isinstance(value, dict):
+                return value
+
+        # HAL _embedded single-record shape.
+        embedded = response_data.get("_embedded")
+        if isinstance(embedded, dict):
+            for value in embedded.values():
+                record = self._find_record(value)
+                if record:
+                    return record
+
+        return response_data
+
+    def _normalize_record(self, record: dict[str, Any]) -> dict[str, Any]:
+        """Strip HAL metadata keys and promote ``_embedded`` sub-resources to the top level.
+
+        Keys listed in :attr:`metadata_keys` (``"_links"`` by default) are removed.  Any keys
+        found inside ``_embedded`` are merged in at the top level; existing top-level keys are
+        not overwritten.
+        """
+        normalized = {key: value for key, value in record.items() if key not in self.metadata_keys}
+
+        embedded = record.get("_embedded")
+        if isinstance(embedded, dict):
+            for key, value in embedded.items():
+                if key not in normalized:
+                    normalized[key] = value
+
+        return normalized

--- a/src/clearskies/backends/adapters/json_api_response_adapter.py
+++ b/src/clearskies/backends/adapters/json_api_response_adapter.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import ResponseAdapter
+
+
+class JsonApiResponseAdapter(ResponseAdapter):
+    """
+    Unwrap strict `JSON:API <https://jsonapi.org>`_ response envelopes for ``ApiBackend``.
+
+    Many public APIs follow the JSON:API specification, which wraps every response in a well-defined
+    envelope.  A list response looks like this:
+
+    ```json
+    {
+        "data": [
+            {"id": "1", "type": "articles", "attributes": {"title": "Hello", "body": "World"}},
+            {"id": "2", "type": "articles", "attributes": {"title": "Bye",   "body": "Now"}}
+        ]
+    }
+    ```
+
+    And a single-resource response like this:
+
+    ```json
+    {
+        "data": {"id": "42", "type": "articles", "attributes": {"title": "Hello", "body": "World"}}
+    }
+    ```
+
+    Without an adapter, ``ApiBackend`` sees the outer ``{"data": [...]}`` shell and tries to map it
+    directly to your model columns — which never works.  ``JsonApiResponseAdapter`` peels that shell
+    away and flattens each resource object so that clearskies sees a plain dictionary:
+
+    ```json
+    {"id": "1", "type": "articles", "title": "Hello", "body": "World"}
+    ```
+
+    ## Normalisation rules
+
+    Each JSON:API resource object is transformed as follows:
+
+    1. All fields inside ``attributes`` are promoted to the top level.
+    2. The resource-level ``id`` and ``type`` are preserved and **always take precedence** over
+       any field of the same name that may exist inside ``attributes``.
+    3. ``relationships``, ``links``, and ``meta`` are **dropped** — they are not part of the
+       flat column mapping layer.
+
+    ## Full working example
+
+    Define a backend subclass that points at the upstream JSON:API service and attach the adapter,
+    then wire it into a model and expose it through a list endpoint:
+
+    ```python
+    import clearskies
+
+
+    class ArticleBackend(clearskies.backends.ApiBackend):
+        def __init__(self):
+            super().__init__(
+                base_url="https://jsonapi.example.com",
+                response_adapter=clearskies.backends.adapters.JsonApiResponseAdapter(),
+            )
+
+
+    class Article(clearskies.Model):
+        id_column_name = "id"
+        backend = ArticleBackend()
+
+        id = clearskies.columns.String()
+        title = clearskies.columns.String()
+        body = clearskies.columns.String()
+
+
+    wsgi = clearskies.contexts.WsgiRef(
+        clearskies.endpoints.List(
+            model_class=Article,
+            readable_column_names=["id", "title", "body"],
+            sortable_column_names=["id"],
+            default_sort_column_name=None,
+            default_limit=10,
+        ),
+        classes=[Article],
+    )
+    wsgi()
+    ```
+
+    Assuming ``https://jsonapi.example.com/articles`` returns a JSON:API envelope, the endpoint
+    unwraps it transparently:
+
+    ```bash
+    $ curl 'http://localhost:8080/' | jq
+    {
+        "status": "success",
+        "error": "",
+        "data": [
+            {"id": "1", "title": "Hello", "body": "World"},
+            {"id": "2", "title": "Bye",   "body": "Now"}
+        ],
+        "pagination": {"number_results": 2, "limit": 10, "next_page": {}},
+        "input_errors": {}
+    }
+    ```
+
+    ## Binding the adapter via DI
+
+    You can also register the adapter in the dependency injection container rather than setting it
+    on the backend instance directly.  The ``ApiBackend`` will pick it up automatically:
+
+    ```python
+    context = clearskies.contexts.WsgiRef(
+        clearskies.endpoints.List(model_class=Article, ...),
+        bindings={"response_adapter": JsonApiResponseAdapter()},
+    )
+    ```
+
+    Note that an adapter set directly on the backend always wins over one registered via DI.
+    """
+
+    def extract_records(self, response_data: Any) -> list[dict[str, Any]] | None:
+        """
+        Return a flattened list of records from a JSON:API ``data`` array.
+
+        Returns ``None`` for every other shape, handing control back to the built-in
+        ``ApiBackend`` extraction logic.
+        """
+        if not isinstance(response_data, dict):
+            return None
+
+        data = response_data.get("data")
+        if isinstance(data, list):
+            return [self._normalize_record(item) for item in data]
+        return None
+
+    def extract_record(self, response_data: Any) -> dict[str, Any] | None:
+        """
+        Return a single flattened record from a JSON:API ``data`` object.
+
+        Also handles bare resource objects (``"attributes"`` at the top level) as a convenience
+        fallback for APIs that strip the outer envelope.  Returns ``None`` for every other shape.
+        """
+        if not isinstance(response_data, dict):
+            return None
+
+        data = response_data.get("data")
+        if isinstance(data, dict):
+            return self._normalize_record(data)
+
+        # Convenience fallback: payload was already stripped or wrapped differently.
+        if "attributes" in response_data:
+            return self._normalize_record(response_data)
+        return None
+
+    def _normalize_record(self, data_block: dict[str, Any]) -> dict[str, Any]:
+        """
+        Flatten a single JSON:API resource object into a plain dict.
+
+        ``attributes`` fields are spread to the top level first.  The resource-level ``id`` and
+        ``type`` are then written on top so they always take precedence over any identically-named
+        attribute — matching the JSON:API specification's intent that ``id`` is a resource
+        identifier, not a mutable attribute.  ``relationships``, ``links``, and ``meta`` are
+        intentionally excluded; their mapping is left to the model's column layer.
+        """
+        # Unpack attributes first so root-level id/type can safely overwrite.
+        attributes = data_block.get("attributes", {})
+        normalized: dict[str, Any] = dict(attributes) if isinstance(attributes, dict) else {}
+
+        # Root resource identifiers always take precedence over same-named attributes.
+        if "id" in data_block:
+            normalized["id"] = data_block["id"]
+        if "type" in data_block:
+            normalized["type"] = data_block["type"]
+
+        return normalized

--- a/tests/backends/adapters/test_hal_json_response_adapter.py
+++ b/tests/backends/adapters/test_hal_json_response_adapter.py
@@ -1,0 +1,162 @@
+import unittest
+
+from clearskies.backends.adapters.hal_json_response_adapter import HalJsonResponseAdapter
+
+
+class HalJsonResponseAdapterTest(unittest.TestCase):
+    def setUp(self):
+        self.adapter = HalJsonResponseAdapter()
+
+    # ── extract_records ────────────────────────────────────────────────────────
+
+    def test_extract_records_bare_list(self):
+        payload = [{"id": 1, "title": "Hello"}, {"id": 2, "title": "World"}]
+        result = self.adapter.extract_records(payload)
+        self.assertEqual(result, payload)
+
+    def test_extract_records_bare_list_of_non_dicts_returns_none(self):
+        self.assertIsNone(self.adapter.extract_records([1, 2, 3]))
+
+    def test_extract_records_embedded_named_subresource(self):
+        payload = {
+            "_links": {"self": {"href": "/articles"}},
+            "_embedded": {
+                "articles": [
+                    {"id": 1, "title": "Hello World", "_links": {"self": {"href": "/articles/1"}}},
+                ]
+            },
+        }
+        result = self.adapter.extract_records(payload)
+        self.assertEqual(result, [{"id": 1, "title": "Hello World"}])
+
+    def test_extract_records_named_list_container_keys(self):
+        for key in ("items", "results", "records", "data", "content", "values", "paths"):
+            payload = {key: [{"id": 1}]}
+            result = self.adapter.extract_records(payload)
+            self.assertEqual(result, [{"id": 1}], f"failed for key={key}")
+
+    def test_extract_records_named_list_container_priority_over_key_map(self):
+        # "items" should win even though the rest of the dict could look like a key->record map.
+        payload = {"items": [{"id": 1}], "meta": {"count": 1}}
+        result = self.adapter.extract_records(payload)
+        self.assertEqual(result, [{"id": 1}])
+
+    def test_extract_records_key_to_record_map_heuristic(self):
+        payload = {
+            "widgets": {"id": 1, "name": "Widget"},
+            "gadgets": {"id": 2, "name": "Gadget"},
+        }
+        result = self.adapter.extract_records(payload)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 2)
+        keys = {record["key"] for record in result}
+        self.assertEqual(keys, {"widgets", "gadgets"})
+        for record in result:
+            self.assertIn("id", record)
+            self.assertIn("name", record)
+
+    def test_extract_records_key_to_record_map_excludes_hal_structural_keys(self):
+        # A response with only _links/_embedded should NOT be misidentified as a key->record map.
+        payload = {"_links": {"self": {"href": "/x"}}, "_embedded": {"items": [{"id": 1}]}}
+        result = self.adapter.extract_records(payload)
+        self.assertEqual(result, [{"id": 1}])
+
+    def test_extract_records_recursive_fallback(self):
+        # "count" is a scalar, so the key->record-map heuristic (step 3) doesn't apply at the top
+        # level; the adapter must recurse into "nested" (step 4) to find the list.
+        payload = {"count": 2, "nested": {"other_count": 3, "items": [{"id": 1}, {"id": 2}]}}
+        result = self.adapter.extract_records(payload)
+        self.assertEqual(result, [{"id": 1}, {"id": 2}])
+
+    def test_extract_records_returns_none_when_nothing_found(self):
+        self.assertIsNone(self.adapter.extract_records({"foo": "bar", "baz": 42}))
+
+    def test_extract_records_returns_none_for_non_dict_non_list(self):
+        self.assertIsNone(self.adapter.extract_records("a string"))
+        self.assertIsNone(self.adapter.extract_records(None))
+        self.assertIsNone(self.adapter.extract_records(42))
+
+    def test_extract_records_strips_links_from_each_record(self):
+        payload = {"items": [{"id": 1, "_links": {"self": {"href": "/x/1"}}}]}
+        result = self.adapter.extract_records(payload)
+        self.assertEqual(result, [{"id": 1}])
+
+    # ── extract_record ──────────────────────────────────────────────────────────
+
+    def test_extract_record_from_named_container_key(self):
+        for key in ("item", "result", "record", "data"):
+            payload = {key: {"id": 1, "_links": {}}}
+            result = self.adapter.extract_record(payload)
+            self.assertEqual(result, {"id": 1}, f"failed for key={key}")
+
+    def test_extract_record_from_list_returns_first_dict(self):
+        payload = [{"id": 1}, {"id": 2}]
+        result = self.adapter.extract_record(payload)
+        self.assertEqual(result, {"id": 1})
+
+    def test_extract_record_from_list_with_no_dicts_returns_none(self):
+        self.assertIsNone(self.adapter.extract_record([1, 2, 3]))
+
+    def test_extract_record_from_embedded(self):
+        payload = {"_embedded": {"article": {"id": 1, "title": "Hello", "_links": {}}}}
+        result = self.adapter.extract_record(payload)
+        self.assertEqual(result, {"id": 1, "title": "Hello"})
+
+    def test_extract_record_bare_object_fallback(self):
+        # No wrapper key at all -- the whole dict is treated as the record.
+        payload = {"id": 1, "title": "Hello"}
+        result = self.adapter.extract_record(payload)
+        self.assertEqual(result, {"id": 1, "title": "Hello"})
+
+    def test_extract_record_returns_none_for_non_dict_non_list(self):
+        self.assertIsNone(self.adapter.extract_record("a string"))
+        self.assertIsNone(self.adapter.extract_record(None))
+        self.assertIsNone(self.adapter.extract_record(42))
+
+    # ── _normalize_record ───────────────────────────────────────────────────────
+
+    def test_normalize_record_strips_metadata_keys(self):
+        record = {"id": 1, "_links": {"self": {"href": "/x/1"}}}
+        result = self.adapter._normalize_record(record)
+        self.assertEqual(result, {"id": 1})
+
+    def test_normalize_record_promotes_embedded_without_overwriting(self):
+        record = {
+            "id": 1,
+            "author": "top-level-author",
+            "_embedded": {"author": "embedded-author", "publisher": "embedded-publisher"},
+        }
+        result = self.adapter._normalize_record(record)
+        # existing top-level key wins
+        self.assertEqual(result["author"], "top-level-author")
+        # new key from _embedded gets promoted
+        self.assertEqual(result["publisher"], "embedded-publisher")
+
+    def test_normalize_record_custom_metadata_keys_subclass(self):
+        class MyAdapter(HalJsonResponseAdapter):
+            metadata_keys = HalJsonResponseAdapter.metadata_keys + ("_meta",)
+
+        adapter = MyAdapter()
+        record = {"id": 1, "_links": {}, "_meta": {"stale": True}}
+        result = adapter._normalize_record(record)
+        self.assertEqual(result, {"id": 1})
+
+    def test_list_container_keys_extendable_via_subclass(self):
+        class MyAdapter(HalJsonResponseAdapter):
+            list_container_keys = HalJsonResponseAdapter.list_container_keys + ("entries",)
+
+        adapter = MyAdapter()
+        result = adapter.extract_records({"entries": [{"id": 1}]})
+        self.assertEqual(result, [{"id": 1}])
+
+    def test_record_container_keys_extendable_via_subclass(self):
+        class MyAdapter(HalJsonResponseAdapter):
+            record_container_keys = HalJsonResponseAdapter.record_container_keys + ("payload",)
+
+        adapter = MyAdapter()
+        result = adapter.extract_record({"payload": {"id": 1}})
+        self.assertEqual(result, {"id": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/backends/adapters/test_json_api_response_adapter.py
+++ b/tests/backends/adapters/test_json_api_response_adapter.py
@@ -1,0 +1,142 @@
+import unittest
+
+from clearskies.backends.adapters.json_api_response_adapter import JsonApiResponseAdapter
+
+
+class JsonApiResponseAdapterTest(unittest.TestCase):
+    def setUp(self):
+        self.adapter = JsonApiResponseAdapter()
+
+    # ── extract_records ────────────────────────────────────────────────────────
+
+    def test_extract_records_returns_flattened_list(self):
+        payload = {
+            "data": [
+                {"id": "1", "type": "articles", "attributes": {"title": "Hello", "body": "World"}},
+                {"id": "2", "type": "articles", "attributes": {"title": "Bye", "body": "Now"}},
+            ]
+        }
+        result = self.adapter.extract_records(payload)
+        self.assertEqual(
+            result,
+            [
+                {"id": "1", "type": "articles", "title": "Hello", "body": "World"},
+                {"id": "2", "type": "articles", "title": "Bye", "body": "Now"},
+            ],
+        )
+
+    def test_extract_records_empty_data_list(self):
+        result = self.adapter.extract_records({"data": []})
+        self.assertEqual(result, [])
+
+    def test_extract_records_returns_none_when_data_is_not_list(self):
+        # data is a dict → single-resource shape, not a list
+        payload = {"data": {"id": "1", "type": "articles", "attributes": {}}}
+        result = self.adapter.extract_records(payload)
+        self.assertIsNone(result)
+
+    def test_extract_records_returns_none_when_data_key_missing(self):
+        result = self.adapter.extract_records({"other": [{"id": "1"}]})
+        self.assertIsNone(result)
+
+    def test_extract_records_returns_none_for_non_dict(self):
+        self.assertIsNone(self.adapter.extract_records([{"id": "1"}]))
+        self.assertIsNone(self.adapter.extract_records("string"))
+        self.assertIsNone(self.adapter.extract_records(None))
+
+    def test_extract_records_no_attributes_key(self):
+        # Resource objects without attributes are still normalised
+        payload = {"data": [{"id": "3", "type": "tags"}]}
+        result = self.adapter.extract_records(payload)
+        self.assertEqual(result, [{"id": "3", "type": "tags"}])
+
+    # ── extract_record ─────────────────────────────────────────────────────────
+
+    def test_extract_record_from_data_dict(self):
+        payload = {"data": {"id": "42", "type": "articles", "attributes": {"title": "Hello", "body": "World"}}}
+        result = self.adapter.extract_record(payload)
+        self.assertEqual(result, {"id": "42", "type": "articles", "title": "Hello", "body": "World"})
+
+    def test_extract_record_returns_none_when_data_is_list(self):
+        # list under data → single-record extraction cannot apply
+        payload = {"data": [{"id": "1", "type": "x", "attributes": {}}]}
+        result = self.adapter.extract_record(payload)
+        self.assertIsNone(result)
+
+    def test_extract_record_fallback_bare_attributes(self):
+        # Payload already stripped of the outer "data" wrapper
+        payload = {"id": "5", "type": "users", "attributes": {"name": "Alice"}}
+        result = self.adapter.extract_record(payload)
+        self.assertEqual(result, {"id": "5", "type": "users", "name": "Alice"})
+
+    def test_extract_record_returns_none_for_non_dict(self):
+        self.assertIsNone(self.adapter.extract_record([]))
+        self.assertIsNone(self.adapter.extract_record("string"))
+        self.assertIsNone(self.adapter.extract_record(42))
+
+    def test_extract_record_returns_none_when_no_data_or_attributes(self):
+        result = self.adapter.extract_record({"other": "stuff"})
+        self.assertIsNone(result)
+
+    # ── _normalize_record ──────────────────────────────────────────────────────
+
+    def test_normalize_record_id_wins_over_attribute_id(self):
+        # JSON:API spec: resource-level id is the canonical identifier.
+        # An attribute named "id" must not shadow it.
+        data_block = {
+            "id": "canonical-id",
+            "type": "widgets",
+            "attributes": {"id": "attribute-id", "name": "Thing"},
+        }
+        result = self.adapter._normalize_record(data_block)
+        self.assertEqual(result["id"], "canonical-id")
+        self.assertEqual(result["name"], "Thing")
+
+    def test_normalize_record_type_wins_over_attribute_type(self):
+        data_block = {
+            "id": "1",
+            "type": "canonical-type",
+            "attributes": {"type": "attribute-type"},
+        }
+        result = self.adapter._normalize_record(data_block)
+        self.assertEqual(result["type"], "canonical-type")
+
+    def test_normalize_record_attributes_spread_to_top(self):
+        data_block = {"id": "1", "attributes": {"foo": "bar", "baz": 42}}
+        result = self.adapter._normalize_record(data_block)
+        self.assertIn("foo", result)
+        self.assertIn("baz", result)
+
+    def test_normalize_record_no_attributes_key(self):
+        data_block = {"id": "7", "type": "empty"}
+        result = self.adapter._normalize_record(data_block)
+        self.assertEqual(result, {"id": "7", "type": "empty"})
+
+    def test_normalize_record_relationships_not_included(self):
+        data_block = {
+            "id": "1",
+            "type": "posts",
+            "attributes": {"title": "Hi"},
+            "relationships": {"author": {"data": {"id": "2", "type": "users"}}},
+        }
+        result = self.adapter._normalize_record(data_block)
+        self.assertNotIn("relationships", result)
+
+    def test_normalize_record_links_not_included(self):
+        data_block = {
+            "id": "1",
+            "type": "posts",
+            "attributes": {"title": "Hi"},
+            "links": {"self": "/posts/1"},
+        }
+        result = self.adapter._normalize_record(data_block)
+        self.assertNotIn("links", result)
+
+    def test_normalize_record_non_dict_attributes_treated_as_empty(self):
+        data_block = {"id": "1", "attributes": "bad-value"}
+        result = self.adapter._normalize_record(data_block)
+        self.assertEqual(result, {"id": "1"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two concrete `ResponseAdapter` implementations for `ApiBackend`'s pluggable response-extraction extension point (introduced in #-- / 9b366ca):

- **`HalJsonResponseAdapter`** — unwraps [HAL+JSON](https://stateless.group/hal_specification.html) envelopes. Handles `_embedded` (idiomatic HAL), named list containers (`items`, `results`, `data`, ...), a key→record-map heuristic for un-keyed named collections, and a recursive fallback scan. Strips `_links` metadata from individual records and promotes `_embedded` sub-resources to the top level without clobbering existing keys.
- **`JsonApiResponseAdapter`** — unwraps strict [JSON:API](https://jsonapi.org) envelopes. Flattens `attributes` to the top level; resource-level `id`/`type` always win over identically-named attributes; drops `relationships`/`links`/`meta`.

Both subclass `ResponseAdapter` and are exported from `clearskies.backends.adapters`. Both return `None` on unrecognized shapes so `ApiBackend` falls through to its existing built-in extraction logic — no breaking change to current behavior.

## Test Plan

- Added `tests/backends/adapters/test_hal_json_response_adapter.py` (22 tests) covering every branch of the HAL adapter's 5-tier fallback lookup, both `extract_records`/`extract_record`, `_normalize_record`, and subclass-extensibility of `list_container_keys`/`record_container_keys`/`metadata_keys`.
- `tests/backends/adapters/test_json_api_response_adapter.py` already existed with 18 tests (unchanged).
- Full suite: `python -m pytest tests/` → 683 passed.
- `ruff check .` and `python -m ty check src/` → clean.
- Pre-commit hooks (ruff check/format, pytest, ty) all passed on the commit.